### PR TITLE
 Add optional local data encryption with data.bin vault

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -15,6 +15,8 @@ class AppConfig {
   static const String _windowWidthKey = 'window_width';
   static const String _windowHeightKey = 'window_height';
   static const String _windowMaximizedKey = 'window_maximized';
+  static const String _encryptionMigrationDismissedKey =
+      'encryption_migration_dismissed';
 
   // Cached app title to avoid repeated async calls
   static String? _cachedAppTitle;
@@ -103,6 +105,17 @@ class AppConfig {
   static Future<void> setDisplayMode(DisplayMode displayMode) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_displayModePreferenceKey, displayMode.name);
+  }
+
+  // Encryption migration prompt suppression
+  static Future<bool> getEncryptionMigrationDismissed() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_encryptionMigrationDismissedKey) ?? false;
+  }
+
+  static Future<void> setEncryptionMigrationDismissed(bool dismissed) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_encryptionMigrationDismissedKey, dismissed);
   }
 
   // Window bounds persistence

--- a/lib/data/repositories/storage_repository.dart
+++ b/lib/data/repositories/storage_repository.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:file_picker/file_picker.dart';
 import '../models/otp_service.dart';
 import '../models/group.dart';
+import '../../services/local_vault_encryption_service.dart';
 import '../../services/twofas_decryption_service.dart';
 import '../../services/secure_storage_service.dart';
 
@@ -13,98 +15,261 @@ class AppData {
   final List<Group> groups;
 
   AppData({required this.services, required this.groups});
+
+  Map<String, dynamic> toJson() {
+    return {
+      'services': services.map((service) => service.toJson()).toList(),
+      'groups': groups.map((group) => group.toJson()).toList(),
+    };
+  }
+
+  String toJsonString() {
+    return jsonEncode(toJson());
+  }
+
+  factory AppData.fromJson(Map<String, dynamic> jsonData) {
+    final services = (jsonData['services'] as List? ?? [])
+        .map((item) => OtpService.fromJson(item))
+        .toList();
+    final groups = (jsonData['groups'] as List? ?? [])
+        .map((item) => Group.fromJson(item))
+        .toList();
+    return AppData(services: services, groups: groups);
+  }
+
+  factory AppData.fromJsonString(String jsonString) {
+    final jsonData = jsonDecode(jsonString) as Map<String, dynamic>;
+    return AppData.fromJson(jsonData);
+  }
+}
+
+enum StorageDataSource {
+  none,
+  plaintextJson,
+  encryptedVault,
+  encryptedBackupJson,
+}
+
+class LoadedAppData {
+  final AppData data;
+  final StorageDataSource source;
+
+  const LoadedAppData({required this.data, required this.source});
+}
+
+class StoragePasswordRequiredException implements Exception {
+  final StorageDataSource source;
+  final String message;
+
+  const StoragePasswordRequiredException(this.source, this.message);
+
+  @override
+  String toString() => message;
+}
+
+class StorageLoadException implements Exception {
+  final StorageDataSource source;
+  final String message;
+
+  const StorageLoadException(this.source, this.message);
+
+  @override
+  String toString() => message;
 }
 
 class StorageRepository {
   static const String _dataFileName = 'data.json';
+  static const String _encryptedDataFileName = 'data.bin';
+  final String? _localPathOverride;
+
+  StorageRepository({String? localPathOverride})
+      : _localPathOverride = localPathOverride;
 
   Future<String> get _localPath async {
+    if (_localPathOverride != null) {
+      return _localPathOverride;
+    }
     final directory = await getApplicationSupportDirectory();
     return directory.path;
   }
 
-  Future<File> getLocalFile() async {
+  Future<Directory> _getLocalDirectory() async {
     final path = await _localPath;
     final directory = Directory(path);
     if (!await directory.exists()) {
       await directory.create(recursive: true);
     }
     debugPrint('Application Data Directory: $path');
-    return File('$path/$_dataFileName');
+    return directory;
+  }
+
+  Future<File> getLocalFile() async {
+    final directory = await _getLocalDirectory();
+    return File('${directory.path}/$_dataFileName');
+  }
+
+  Future<File> getEncryptedLocalFile() async {
+    final directory = await _getLocalDirectory();
+    return File('${directory.path}/$_encryptedDataFileName');
+  }
+
+  Future<String> readAppDataJson() async {
+    final file = await getLocalFile();
+    return file.readAsString();
+  }
+
+  Future<Uint8List> readEncryptedAppData() async {
+    final file = await getEncryptedLocalFile();
+    return file.readAsBytes();
+  }
+
+  Future<void> writeAppDataJson(AppData data) async {
+    final file = await getLocalFile();
+    await file.writeAsString(data.toJsonString());
+  }
+
+  Future<void> saveEncryptedData(AppData data, String password) async {
+    final encryptedFile = await getEncryptedLocalFile();
+    final tempFile = File('${encryptedFile.path}.tmp');
+    final plaintextJson = serializePlaintextAppData(data);
+
+    try {
+      final encryptedBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+      );
+      await tempFile.writeAsBytes(encryptedBytes, flush: true);
+
+      final verifiedJson = await LocalVaultEncryptionService.decrypt(
+        await tempFile.readAsBytes(),
+        password,
+      );
+      if (verifiedJson != plaintextJson) {
+        throw const FileSystemException(
+          'Encrypted vault verification failed after write',
+        );
+      }
+
+      if (await encryptedFile.exists()) {
+        await encryptedFile.delete();
+      }
+
+      await tempFile.rename(encryptedFile.path);
+    } finally {
+      if (await tempFile.exists()) {
+        await tempFile.delete();
+      }
+    }
+  }
+
+  Future<void> deletePlaintextData() async {
+    final file = await getLocalFile();
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  Future<void> migratePlaintextDataToEncryptedVault(
+    AppData data,
+    String password,
+  ) async {
+    await saveEncryptedData(data, password);
+    await deletePlaintextData();
+  }
+
+  Future<bool> hasPlaintextData() async {
+    final file = await getLocalFile();
+    return file.exists();
+  }
+
+  Future<bool> hasEncryptedData() async {
+    final file = await getEncryptedLocalFile();
+    return file.exists();
+  }
+
+  Future<bool> hasAnyLocalData() async {
+    final results = await Future.wait([
+      hasEncryptedData(),
+      hasPlaintextData(),
+    ]);
+    return results.any((exists) => exists);
+  }
+
+  AppData parsePlaintextAppData(String jsonString) {
+    return AppData.fromJsonString(jsonString);
+  }
+
+  String serializePlaintextAppData(AppData data) {
+    return data.toJsonString();
+  }
+
+  bool isEncryptedLocalSource(StorageDataSource source) {
+    return source == StorageDataSource.encryptedVault;
+  }
+
+  Map<String, dynamic> decodeJsonObject(String jsonString) {
+    return jsonDecode(jsonString) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> readPlaintextJsonObject() async {
+    final contents = await readAppDataJson();
+    return decodeJsonObject(contents);
+  }
+
+  Future<LoadedAppData> loadStoredData({String? password}) async {
+    try {
+      if (await hasEncryptedData()) {
+        return await _loadEncryptedVaultData(password: password);
+      }
+      if (await hasPlaintextData()) {
+        return await _loadPlaintextJsonData(password: password);
+      }
+      return LoadedAppData(
+        data: AppData(services: [], groups: []),
+        source: StorageDataSource.none,
+      );
+    } on StoragePasswordRequiredException {
+      rethrow;
+    } on StorageLoadException {
+      rethrow;
+    } catch (e) {
+      throw StorageLoadException(
+        StorageDataSource.none,
+        'Error loading data: $e',
+      );
+    }
   }
 
   Future<AppData> loadData({String? password}) async {
     try {
-      final file = await getLocalFile();
-      if (await file.exists()) {
-        String contents = await file.readAsString();
-        Map<String, dynamic> jsonData = jsonDecode(contents);
-
-        // Check if backup is encrypted
-        if (TwoFasDecryptionService.isEncrypted(jsonData)) {
-          // Try provided password first, then stored password
-          String? effectivePassword = password ??
-              await SecureStorageService.getStoredPassword(contents);
-
-          if (effectivePassword == null) {
-            throw ArgumentError('Password required for encrypted backup');
-          }
-
-          // Decrypt the services
-          final decryptedServices = await TwoFasDecryptionService.decryptBackup(
-              jsonData, effectivePassword);
-          final servicesData = jsonDecode(decryptedServices) as List;
-
-          // If decryption succeeded and password was provided manually, store it securely
-          if (password != null) {
-            try {
-              await SecureStorageService.storePassword(password, contents);
-            } catch (e) {
-              debugPrint('Warning: Failed to store password securely: $e');
-              // Don't fail the whole operation if password storage fails
-            }
-          }
-
-          // Parse decrypted services
-          List<OtpService> services =
-              servicesData.map((item) => OtpService.fromJson(item)).toList();
-
-          // Parse groups (these are not encrypted in 2FAS format)
-          List<Group> groups = (jsonData['groups'] as List? ?? [])
-              .map((item) => Group.fromJson(item))
-              .toList();
-
-          return AppData(services: services, groups: groups);
-        } else {
-          // Handle unencrypted backup
-          List<OtpService> services = (jsonData['services'] as List? ?? [])
-              .map((item) => OtpService.fromJson(item))
-              .toList();
-
-          List<Group> groups = (jsonData['groups'] as List? ?? [])
-              .map((item) => Group.fromJson(item))
-              .toList();
-
-          return AppData(services: services, groups: groups);
-        }
-      } else {
-        debugPrint('Data file not found at: ${await getLocalFile()}');
-        return AppData(services: [], groups: []);
-      }
+      final result = await loadStoredData(password: password);
+      return result.data;
+    } on StoragePasswordRequiredException {
+      rethrow;
+    } on StorageLoadException {
+      rethrow;
     } catch (e) {
       debugPrint('Error loading data: $e');
-      rethrow; // Re-throw to allow proper error handling upstream
+      rethrow;
     }
   }
 
-  Future<void> saveData(AppData data) async {
+  Future<void> saveData(
+    AppData data, {
+    StorageDataSource source = StorageDataSource.plaintextJson,
+    String? password,
+  }) async {
     try {
-      final file = await getLocalFile();
-      Map<String, dynamic> jsonData = {
-        'services': data.services.map((s) => s.toJson()).toList(),
-        'groups': data.groups.map((g) => g.toJson()).toList(),
-      };
-      await file.writeAsString(jsonEncode(jsonData));
+      if (isEncryptedLocalSource(source)) {
+        if (password == null || password.isEmpty) {
+          throw ArgumentError('Password required for encrypted vault');
+        }
+        await saveEncryptedData(data, password);
+        await deletePlaintextData();
+        return;
+      }
+
+      await writeAppDataJson(data);
     } catch (e) {
       debugPrint('Error saving data: $e');
       rethrow;
@@ -130,7 +295,7 @@ class StorageRepository {
     }
   }
 
-  /// Imports a 2FAS backup file from the given path and copies it to app storage
+  /// Imports a 2FAS backup file from the given path and parses its data.
   Future<AppData> importBackupFile(String filePath, {String? password}) async {
     try {
       final sourceFile = File(filePath);
@@ -147,11 +312,8 @@ class StorageRepository {
         throw ArgumentError('Selected file is not a valid 2FAS backup');
       }
 
-      // Test loading the data first before copying
-      AppData testData = await _parseBackupData(jsonData, contents, password);
-
-      // If parsing succeeded, copy the file to app storage
-      await _copyToAppStorage(sourceFile);
+      // Parse the backup data for merging into local storage
+      AppData testData = await _parseBackupData(jsonData, password);
 
       debugPrint('Successfully imported backup from: $filePath');
       return testData;
@@ -164,11 +326,87 @@ class StorageRepository {
   /// Checks if the current app storage has a data file
   Future<bool> hasExistingData() async {
     try {
-      final file = await getLocalFile();
-      return await file.exists();
+      return await hasAnyLocalData();
     } catch (e) {
       debugPrint('Error checking existing data: $e');
       return false;
+    }
+  }
+
+  Future<LoadedAppData> _loadEncryptedVaultData({String? password}) async {
+    if (password == null || password.isEmpty) {
+      throw const StoragePasswordRequiredException(
+        StorageDataSource.encryptedVault,
+        'Password required for encrypted vault',
+      );
+    }
+
+    try {
+      final contents = await readEncryptedAppData();
+      final decryptedJson =
+          await LocalVaultEncryptionService.decrypt(contents, password);
+      return LoadedAppData(
+        data: parsePlaintextAppData(decryptedJson),
+        source: StorageDataSource.encryptedVault,
+      );
+    } catch (e) {
+      throw StorageLoadException(
+        StorageDataSource.encryptedVault,
+        'Failed to unlock encrypted vault: $e',
+      );
+    }
+  }
+
+  Future<LoadedAppData> _loadPlaintextJsonData({String? password}) async {
+    final contents = await readAppDataJson();
+    final jsonData = decodeJsonObject(contents);
+
+    if (!TwoFasDecryptionService.isEncrypted(jsonData)) {
+      return LoadedAppData(
+        data: parsePlaintextAppData(contents),
+        source: StorageDataSource.plaintextJson,
+      );
+    }
+
+    final effectivePassword =
+        password ?? await SecureStorageService.getStoredPassword(contents);
+    if (effectivePassword == null || effectivePassword.isEmpty) {
+      throw const StoragePasswordRequiredException(
+        StorageDataSource.encryptedBackupJson,
+        'Password required for encrypted backup',
+      );
+    }
+
+    try {
+      final decryptedServices = await TwoFasDecryptionService.decryptBackup(
+        jsonData,
+        effectivePassword,
+      );
+      final servicesData = jsonDecode(decryptedServices) as List;
+
+      if (password != null) {
+        try {
+          await SecureStorageService.storePassword(password, contents);
+        } catch (e) {
+          debugPrint('Warning: Failed to store password securely: $e');
+        }
+      }
+
+      final services =
+          servicesData.map((item) => OtpService.fromJson(item)).toList();
+      final groups = (jsonData['groups'] as List? ?? [])
+          .map((item) => Group.fromJson(item))
+          .toList();
+
+      return LoadedAppData(
+        data: AppData(services: services, groups: groups),
+        source: StorageDataSource.encryptedBackupJson,
+      );
+    } catch (e) {
+      throw StorageLoadException(
+        StorageDataSource.encryptedBackupJson,
+        'Failed to decrypt backup: $e',
+      );
     }
   }
 
@@ -181,7 +419,7 @@ class StorageRepository {
   }
 
   Future<AppData> _parseBackupData(
-      Map<String, dynamic> jsonData, String contents, String? password) async {
+      Map<String, dynamic> jsonData, String? password) async {
     // Check if backup is encrypted
     if (TwoFasDecryptionService.isEncrypted(jsonData)) {
       if (password == null) {
@@ -204,22 +442,7 @@ class StorageRepository {
 
       return AppData(services: services, groups: groups);
     } else {
-      // Handle unencrypted backup
-      List<OtpService> services = (jsonData['services'] as List? ?? [])
-          .map((item) => OtpService.fromJson(item))
-          .toList();
-
-      List<Group> groups = (jsonData['groups'] as List? ?? [])
-          .map((item) => Group.fromJson(item))
-          .toList();
-
-      return AppData(services: services, groups: groups);
+      return AppData.fromJson(jsonData);
     }
-  }
-
-  Future<void> _copyToAppStorage(File sourceFile) async {
-    final destinationFile = await getLocalFile();
-    await sourceFile.copy(destinationFile.path);
-    debugPrint('Copied backup to app storage: ${destinationFile.path}');
   }
 }

--- a/lib/data/repositories/storage_repository.dart
+++ b/lib/data/repositories/storage_repository.dart
@@ -67,11 +67,18 @@ class StoragePasswordRequiredException implements Exception {
   String toString() => message;
 }
 
+enum VaultLoadErrorKind { incorrectPassword, corruptedVault, unknown }
+
 class StorageLoadException implements Exception {
   final StorageDataSource source;
   final String message;
+  final VaultLoadErrorKind kind;
 
-  const StorageLoadException(this.source, this.message);
+  const StorageLoadException(
+    this.source,
+    this.message, {
+    this.kind = VaultLoadErrorKind.unknown,
+  });
 
   @override
   String toString() => message;
@@ -123,12 +130,21 @@ class StorageRepository {
     return file.readAsBytes();
   }
 
+  Future<VaultKdfParameters> readVaultKdfParameters() async {
+    final contents = await readEncryptedAppData();
+    return LocalVaultEncryptionService.readKdfParameters(contents);
+  }
+
   Future<void> writeAppDataJson(AppData data) async {
     final file = await getLocalFile();
     await file.writeAsString(data.toJsonString());
   }
 
-  Future<void> saveEncryptedData(AppData data, String password) async {
+  Future<void> saveEncryptedData(
+    AppData data,
+    String password, {
+    bool verify = false,
+  }) async {
     final encryptedFile = await getEncryptedLocalFile();
     final tempFile = File('${encryptedFile.path}.tmp');
     final plaintextJson = serializePlaintextAppData(data);
@@ -140,15 +156,48 @@ class StorageRepository {
       );
       await tempFile.writeAsBytes(encryptedBytes, flush: true);
 
-      final verifiedJson = await LocalVaultEncryptionService.decrypt(
-        await tempFile.readAsBytes(),
-        password,
-      );
-      if (verifiedJson != plaintextJson) {
-        throw const FileSystemException(
-          'Encrypted vault verification failed after write',
+      if (verify) {
+        final verifiedJson = await LocalVaultEncryptionService.decrypt(
+          await tempFile.readAsBytes(),
+          password,
         );
+        if (verifiedJson != plaintextJson) {
+          throw const FileSystemException(
+            'Encrypted vault verification failed after write',
+          );
+        }
       }
+
+      if (await encryptedFile.exists()) {
+        await encryptedFile.delete();
+      }
+
+      await tempFile.rename(encryptedFile.path);
+    } finally {
+      if (await tempFile.exists()) {
+        await tempFile.delete();
+      }
+    }
+  }
+
+  Future<void> saveEncryptedDataWithKey(
+    AppData data,
+    Uint8List key, {
+    required Uint8List salt,
+    required int iterations,
+  }) async {
+    final encryptedFile = await getEncryptedLocalFile();
+    final tempFile = File('${encryptedFile.path}.tmp');
+    final plaintextJson = serializePlaintextAppData(data);
+
+    try {
+      final encryptedBytes = await LocalVaultEncryptionService.encryptWithKey(
+        plaintextJson,
+        key,
+        salt: salt,
+        iterations: iterations,
+      );
+      await tempFile.writeAsBytes(encryptedBytes, flush: true);
 
       if (await encryptedFile.exists()) {
         await encryptedFile.delete();
@@ -173,7 +222,7 @@ class StorageRepository {
     AppData data,
     String password,
   ) async {
-    await saveEncryptedData(data, password);
+    await saveEncryptedData(data, password, verify: true);
     await deletePlaintextData();
   }
 
@@ -258,13 +307,14 @@ class StorageRepository {
     AppData data, {
     StorageDataSource source = StorageDataSource.plaintextJson,
     String? password,
+    bool verify = false,
   }) async {
     try {
       if (isEncryptedLocalSource(source)) {
         if (password == null || password.isEmpty) {
           throw ArgumentError('Password required for encrypted vault');
         }
-        await saveEncryptedData(data, password);
+        await saveEncryptedData(data, password, verify: verify);
         await deletePlaintextData();
         return;
       }
@@ -350,9 +400,18 @@ class StorageRepository {
         source: StorageDataSource.encryptedVault,
       );
     } catch (e) {
+      final VaultLoadErrorKind kind;
+      if (e is ArgumentError) {
+        kind = VaultLoadErrorKind.incorrectPassword;
+      } else if (e is FormatException || e is UnsupportedError) {
+        kind = VaultLoadErrorKind.corruptedVault;
+      } else {
+        kind = VaultLoadErrorKind.unknown;
+      }
       throw StorageLoadException(
         StorageDataSource.encryptedVault,
         'Failed to unlock encrypted vault: $e',
+        kind: kind,
       );
     }
   }
@@ -423,7 +482,10 @@ class StorageRepository {
     // Check if backup is encrypted
     if (TwoFasDecryptionService.isEncrypted(jsonData)) {
       if (password == null) {
-        throw ArgumentError('Password required for encrypted backup');
+        throw const StoragePasswordRequiredException(
+          StorageDataSource.encryptedBackupJson,
+          'Password required for encrypted backup',
+        );
       }
 
       // Decrypt the services

--- a/lib/presentation/pages/dashboard_page.dart
+++ b/lib/presentation/pages/dashboard_page.dart
@@ -66,6 +66,7 @@ class _DashboardPageState extends State<DashboardPage> {
             ? PasswordDialogMode.unlockVault
             : PasswordDialogMode.decryptBackup,
         errorMessage: otpState.encryptionError,
+        errorKind: otpState.encryptionErrorKind,
       ),
     );
 
@@ -304,6 +305,7 @@ class _DashboardPageState extends State<DashboardPage> {
       builder: (context) => PasswordDialog(
         mode: PasswordDialogMode.decryptBackup,
         errorMessage: otpState.encryptionError,
+        errorKind: otpState.encryptionErrorKind,
       ),
     );
 
@@ -578,7 +580,13 @@ class _DashboardPageState extends State<DashboardPage> {
                       ),
                       const SizedBox(width: 16),
                       OutlinedButton(
-                        onPressed: () => otpState.clearStoredPassword(),
+                        onPressed: () {
+                          if (isLocalVault) {
+                            _showPasswordDialog();
+                          } else {
+                            otpState.clearStoredPassword();
+                          }
+                        },
                         child: const Text('Use Different Password'),
                       ),
                       const SizedBox(width: 16),

--- a/lib/presentation/pages/dashboard_page.dart
+++ b/lib/presentation/pages/dashboard_page.dart
@@ -20,6 +20,7 @@ class DashboardPage extends StatefulWidget {
 class _DashboardPageState extends State<DashboardPage> {
   final TextEditingController _searchController = TextEditingController();
   final bool _sortAscending = true;
+  bool _migrationPromptHandled = false;
 
   @override
   void initState() {
@@ -37,6 +38,23 @@ class _DashboardPageState extends State<DashboardPage> {
     }
   }
 
+  void _checkForEncryptionMigrationPrompt() {
+    final otpState = Provider.of<OtpState>(context, listen: false);
+    if (!otpState.shouldPromptForEncryptionMigration ||
+        otpState.requiresPassword ||
+        otpState.isLoading ||
+        _migrationPromptHandled) {
+      return;
+    }
+
+    _migrationPromptHandled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _showEncryptionMigrationPrompt();
+      }
+    });
+  }
+
   void _showPasswordDialog() async {
     final otpState = Provider.of<OtpState>(context, listen: false);
 
@@ -44,6 +62,9 @@ class _DashboardPageState extends State<DashboardPage> {
       context: context,
       barrierDismissible: false,
       builder: (context) => PasswordDialog(
+        mode: otpState.requiresLocalVaultPassword
+            ? PasswordDialogMode.unlockVault
+            : PasswordDialogMode.decryptBackup,
         errorMessage: otpState.encryptionError,
       ),
     );
@@ -53,6 +74,147 @@ class _DashboardPageState extends State<DashboardPage> {
       if (otpState.encryptionError != null && mounted) {
         _showPasswordDialog(); // Show dialog again with error
       }
+    }
+  }
+
+  Future<void> _showEncryptionMigrationPrompt() async {
+    final otpState = Provider.of<OtpState>(context, listen: false);
+
+    final shouldEncrypt = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Encrypt Local Data'),
+        content: const Text(
+          'LibreOTP loaded plaintext local data from data.json. You can migrate it into an encrypted local vault and remove the plaintext file.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Not Now'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Encrypt'),
+          ),
+        ],
+      ),
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    if (shouldEncrypt != true) {
+      otpState.dismissEncryptionMigrationPrompt();
+      return;
+    }
+
+    final password = await showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const PasswordDialog(
+        mode: PasswordDialogMode.createVaultPassword,
+      ),
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    if (password == null) {
+      otpState.dismissEncryptionMigrationPrompt();
+      return;
+    }
+
+    try {
+      await otpState.migratePlaintextDataToEncryptedVault(password);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Local data encrypted and migrated to data.bin'),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Encryption Failed'),
+          content: Text(
+            'LibreOTP could not migrate the local data into the encrypted vault.\n\n$e',
+          ),
+          actions: [
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+      _migrationPromptHandled = false;
+    }
+  }
+
+  Future<void> _showChangeVaultPasswordDialog() async {
+    final otpState = Provider.of<OtpState>(context, listen: false);
+    final password = await showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const PasswordDialog(
+        mode: PasswordDialogMode.changeVaultPassword,
+      ),
+    );
+
+    if (!mounted || password == null) {
+      return;
+    }
+
+    try {
+      await otpState.changeLocalVaultPassword(password);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Vault password updated'),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Password Change Failed'),
+          content: Text(
+            'LibreOTP could not update the vault password.\n\n$e',
+          ),
+          actions: [
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleStorageAction(_StorageAction action) async {
+    switch (action) {
+      case _StorageAction.encryptLocalData:
+        await _showEncryptionMigrationPrompt();
+        break;
+      case _StorageAction.changeVaultPassword:
+        await _showChangeVaultPasswordDialog();
+        break;
     }
   }
 
@@ -140,6 +302,7 @@ class _DashboardPageState extends State<DashboardPage> {
       context: context,
       barrierDismissible: false,
       builder: (context) => PasswordDialog(
+        mode: PasswordDialogMode.decryptBackup,
         errorMessage: otpState.encryptionError,
       ),
     );
@@ -204,7 +367,10 @@ class _DashboardPageState extends State<DashboardPage> {
                       '${otpState.services.length} services',
                       style: TextStyle(
                         fontSize: 14,
-                        color: Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.8),
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimary
+                            .withValues(alpha: 0.8),
                         fontWeight: FontWeight.normal,
                       ),
                     );
@@ -214,17 +380,64 @@ class _DashboardPageState extends State<DashboardPage> {
             ),
             actions: [
               IconButton(
-                icon: Icon(Icons.upload_file, color: Theme.of(context).colorScheme.onPrimary),
+                icon: Icon(Icons.upload_file,
+                    color: Theme.of(context).colorScheme.onPrimary),
                 tooltip: 'Import 2FAS Backup',
                 onPressed: () => _showImportDialog(context),
               ),
               IconButton(
-                icon: Icon(Icons.folder_open, color: Theme.of(context).colorScheme.onPrimary),
+                icon: Icon(Icons.folder_open,
+                    color: Theme.of(context).colorScheme.onPrimary),
                 tooltip: 'Show Data Directory',
                 onPressed: () => _showDataDirectory(context),
               ),
+              Consumer<OtpState>(
+                builder: (context, otpState, child) {
+                  final items = <PopupMenuEntry<_StorageAction>>[];
+                  if (otpState.canEncryptLocalData) {
+                    items.add(
+                      const PopupMenuItem(
+                        value: _StorageAction.encryptLocalData,
+                        child: Row(
+                          children: [
+                            Icon(Icons.lock),
+                            SizedBox(width: 8),
+                            Text('Encrypt Local Data'),
+                          ],
+                        ),
+                      ),
+                    );
+                  }
+                  if (otpState.usesEncryptedLocalStorage) {
+                    items.add(
+                      const PopupMenuItem(
+                        value: _StorageAction.changeVaultPassword,
+                        child: Row(
+                          children: [
+                            Icon(Icons.password),
+                            SizedBox(width: 8),
+                            Text('Change Vault Password'),
+                          ],
+                        ),
+                      ),
+                    );
+                  }
+                  if (items.isEmpty) {
+                    return const SizedBox.shrink();
+                  }
+
+                  return PopupMenuButton<_StorageAction>(
+                    icon: Icon(Icons.lock_outline,
+                        color: Theme.of(context).colorScheme.onPrimary),
+                    tooltip: 'Storage',
+                    onSelected: _handleStorageAction,
+                    itemBuilder: (_) => items,
+                  );
+                },
+              ),
               PopupMenuButton<ThemeMode>(
-                icon: Icon(Icons.brightness_medium, color: Theme.of(context).colorScheme.onPrimary),
+                icon: Icon(Icons.brightness_medium,
+                    color: Theme.of(context).colorScheme.onPrimary),
                 tooltip: 'Theme',
                 onSelected: widget.onThemeChanged,
                 itemBuilder: (context) => [
@@ -261,7 +474,8 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               ),
               IconButton(
-                icon: Icon(Icons.info_outline, color: Theme.of(context).colorScheme.onPrimary),
+                icon: Icon(Icons.info_outline,
+                    color: Theme.of(context).colorScheme.onPrimary),
                 tooltip: 'About',
                 onPressed: () => _showAboutDialog(context),
               ),
@@ -272,8 +486,12 @@ class _DashboardPageState extends State<DashboardPage> {
       ),
       body: Consumer<OtpState>(
         builder: (context, otpState, child) {
-          if (otpState.isLoading) {
-            return Center(
+          _checkForEncryptionMigrationPrompt();
+          final showFullScreenLoading = otpState.isLoading && !otpState.isBusy;
+          late final Widget content;
+
+          if (showFullScreenLoading) {
+            content = Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -289,23 +507,32 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               ),
             );
-          }
-
-          if (otpState.requiresPassword) {
-            return Center(
+          } else if (otpState.requiresPassword) {
+            final isLocalVault = otpState.requiresLocalVaultPassword;
+            content = Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.lock, size: 64, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                  Icon(Icons.lock,
+                      size: 64,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant),
                   const SizedBox(height: 16),
-                  const Text(
-                    'Encrypted Backup Detected',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  Text(
+                    isLocalVault
+                        ? 'Encrypted Vault Detected'
+                        : 'Encrypted Backup Detected',
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Please provide the password to decrypt your backup.',
-                    style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                    isLocalVault
+                        ? 'Please provide the password to unlock your local vault.'
+                        : 'Please provide the password to decrypt your backup.',
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant),
                   ),
                   const SizedBox(height: 24),
                   ElevatedButton.icon(
@@ -316,23 +543,29 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               ),
             );
-          }
-
-          if (otpState.encryptionError != null) {
-            return Center(
+          } else if (otpState.encryptionError != null) {
+            final isLocalVault = otpState.requiresLocalVaultPassword;
+            content = Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.error, size: 64, color: Theme.of(context).colorScheme.error),
+                  Icon(Icons.error,
+                      size: 64, color: Theme.of(context).colorScheme.error),
                   const SizedBox(height: 16),
-                  const Text(
-                    'Failed to Load Backup',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  Text(
+                    isLocalVault
+                        ? 'Failed to Unlock Vault'
+                        : 'Failed to Load Backup',
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(height: 8),
                   Text(
                     otpState.encryptionError!,
-                    style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant),
                     textAlign: TextAlign.center,
                   ),
                   const SizedBox(height: 16),
@@ -359,15 +592,14 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               ),
             );
-          }
-
-          // Show import UI when no data exists
-          if (!otpState.hasExistingData && otpState.services.isEmpty) {
-            return Center(
+          } else if (!otpState.hasExistingData && otpState.services.isEmpty) {
+            // Show import UI when no data exists
+            content = Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.security, size: 64, color: Theme.of(context).colorScheme.primary),
+                  Icon(Icons.security,
+                      size: 64, color: Theme.of(context).colorScheme.primary),
                   const SizedBox(height: 16),
                   const Text(
                     'Welcome to LibreOTP',
@@ -376,7 +608,9 @@ class _DashboardPageState extends State<DashboardPage> {
                   const SizedBox(height: 8),
                   Text(
                     'Import your 2FAS backup to get started',
-                    style: TextStyle(fontSize: 16, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                        fontSize: 16,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant),
                   ),
                   const SizedBox(height: 24),
                   ElevatedButton.icon(
@@ -391,53 +625,109 @@ class _DashboardPageState extends State<DashboardPage> {
                   const SizedBox(height: 16),
                   Text(
                     'Export your data from the 2FAS app and select the JSON file',
-                    style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                        fontSize: 12,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant),
                     textAlign: TextAlign.center,
                   ),
                 ],
               ),
             );
-          }
-
-          return Stack(
-            children: [
-              Column(
-                children: [
-                  SearchBarWidget(
-                    controller: _searchController,
-                    onClear: () {
-                      _searchController.clear();
-                      _updateSearchQuery();
-                    },
-                    onChanged: (_) => _updateSearchQuery(),
-                    displayMode: otpState.displayMode,
-                    onDisplayModeChanged: (mode) => otpState.setDisplayMode(mode),
-                  ),
-                  Expanded(
-                    child: Container(
-                      alignment: Alignment.topLeft,
-                      padding: const EdgeInsets.all(8.0),
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.vertical,
+          } else {
+            content = Stack(
+              children: [
+                Column(
+                  children: [
+                    SearchBarWidget(
+                      controller: _searchController,
+                      onClear: () {
+                        _searchController.clear();
+                        _updateSearchQuery();
+                      },
+                      onChanged: (_) => _updateSearchQuery(),
+                      displayMode: otpState.displayMode,
+                      onDisplayModeChanged: (mode) =>
+                          otpState.setDisplayMode(mode),
+                    ),
+                    Expanded(
+                      child: Container(
+                        alignment: Alignment.topLeft,
+                        padding: const EdgeInsets.all(8.0),
                         child: SingleChildScrollView(
-                          scrollDirection: Axis.horizontal,
-                          child: OtpTable(
-                            groupedServices: otpState.groupedServices,
-                            groupNames: otpState.getGroupNames(),
-                            onRowTap: (groupId, index) =>
-                                otpState.generateOtp(groupId, index, context),
-                            sortAscending: _sortAscending,
+                          scrollDirection: Axis.vertical,
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: OtpTable(
+                              groupedServices: otpState.groupedServices,
+                              groupNames: otpState.getGroupNames(),
+                              onRowTap: (groupId, index) =>
+                                  otpState.generateOtp(groupId, index, context),
+                              sortAscending: _sortAscending,
+                            ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                ],
-              ),
+                  ],
+                ),
+              ],
+            );
+          }
+
+          return Stack(
+            children: [
+              Positioned.fill(child: content),
+              if (otpState.isBusy) const _BusyOverlay(),
             ],
           );
         },
       ),
+    );
+  }
+}
+
+enum _StorageAction {
+  encryptLocalData,
+  changeVaultPassword,
+}
+
+class _BusyOverlay extends StatelessWidget {
+  const _BusyOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    final otpState = context.watch<OtpState>();
+
+    return Stack(
+      children: [
+        const Positioned.fill(
+          child: ModalBarrier(
+            dismissible: false,
+            color: Colors.black54,
+          ),
+        ),
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 320),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const CircularProgressIndicator(),
+                    const SizedBox(height: 16),
+                    Text(
+                      otpState.busyMessage ?? 'Working with encrypted data...',
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/state/otp_state.dart
+++ b/lib/presentation/state/otp_state.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import '../../config/app_config.dart';
 import '../../config/display_mode.dart';
@@ -8,6 +9,7 @@ import '../../data/models/group.dart';
 import '../../data/repositories/storage_repository.dart';
 import '../../domain/services/otp_service.dart';
 import '../../utils/clipboard_utils.dart';
+import '../../services/local_vault_encryption_service.dart';
 import '../../services/secure_storage_service.dart';
 import '../../services/twofas_icon_service.dart';
 import 'otp_display_state.dart';
@@ -42,6 +44,7 @@ class OtpState extends ChangeNotifier {
   bool _isLoading = true;
   bool _requiresPassword = false;
   String? _encryptionError;
+  VaultLoadErrorKind? _encryptionErrorKind;
   bool _disposed = false;
   bool _hasExistingData = false;
   String? _selectedFilePath;
@@ -51,6 +54,9 @@ class OtpState extends ChangeNotifier {
   bool _shouldPromptForEncryptionMigration = false;
   StorageDataSource _activeStorageSource = StorageDataSource.none;
   String? _localVaultPassword;
+  Uint8List? _vaultKey;
+  Uint8List? _vaultSalt;
+  int? _vaultIterations;
   BusyOperation? _busyOperation;
 
   // Helper method to yield control to allow UI updates
@@ -117,6 +123,7 @@ class OtpState extends ChangeNotifier {
   bool get requiresBackupPassword =>
       _passwordPromptReason == PasswordPromptReason.encryptedBackup;
   String? get encryptionError => _encryptionError;
+  VaultLoadErrorKind? get encryptionErrorKind => _encryptionErrorKind;
   bool get hasExistingData => _hasExistingData;
   String? get selectedFilePath => _selectedFilePath;
   DisplayMode get displayMode => _displayMode;
@@ -150,6 +157,7 @@ class OtpState extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
+    _clearVaultSessionKey();
     _cancelAllTimers();
     _debouncedSaveTimer?.cancel();
     _usageResortTimer?.cancel();
@@ -204,6 +212,7 @@ class OtpState extends ChangeNotifier {
     _isLoading = true;
     _requiresPassword = false;
     _encryptionError = null;
+    _encryptionErrorKind = null;
     _passwordPromptReason = PasswordPromptReason.none;
     if (!_disposed) {
       notifyListeners();
@@ -235,6 +244,7 @@ class OtpState extends ChangeNotifier {
     _isLoading = true;
     _requiresPassword = false;
     _encryptionError = null;
+    _encryptionErrorKind = null;
     _passwordPromptReason = PasswordPromptReason.none;
     if (!_disposed) {
       notifyListeners();
@@ -284,6 +294,7 @@ class OtpState extends ChangeNotifier {
           ? PasswordPromptReason.encryptedVault
           : PasswordPromptReason.encryptedBackup;
       _encryptionError = e.toString();
+      _encryptionErrorKind = e.kind;
       debugPrint(_encryptionError);
       _isLoading = false;
       if (!_disposed) {
@@ -305,6 +316,7 @@ class OtpState extends ChangeNotifier {
   Future<void> loadDataWithPassword(String password) async {
     _isLoading = true;
     _encryptionError = null;
+    _encryptionErrorKind = null;
     notifyListeners();
 
     final busyOperation =
@@ -320,6 +332,11 @@ class OtpState extends ChangeNotifier {
         _groupedServices = _groupServicesByGroup();
         _requiresPassword = false;
         _passwordPromptReason = PasswordPromptReason.none;
+        _encryptionErrorKind = null;
+
+        if (result.source == StorageDataSource.encryptedVault) {
+          await _cacheVaultSessionKey(password);
+        }
 
         // Preload icons for imported services asynchronously
         _preloadIconsForServices();
@@ -330,6 +347,7 @@ class OtpState extends ChangeNotifier {
             : PasswordPromptReason.encryptedBackup;
       } on StorageLoadException catch (e) {
         _encryptionError = e.toString();
+        _encryptionErrorKind = e.kind;
         _requiresPassword = true;
         _passwordPromptReason = e.source == StorageDataSource.encryptedVault
             ? PasswordPromptReason.encryptedVault
@@ -634,14 +652,15 @@ class OtpState extends ChangeNotifier {
         _preloadIconsForServices();
 
         return true;
+      } on StoragePasswordRequiredException catch (_) {
+        _requiresPassword = true;
+        _passwordPromptReason = PasswordPromptReason.encryptedBackup;
+        _encryptionError = null;
+        _isLoading = false;
+        notifyListeners();
+        return false;
       } catch (e) {
-        if (e.toString().contains('Password required')) {
-          _requiresPassword = true;
-          _passwordPromptReason = PasswordPromptReason.encryptedBackup;
-          _encryptionError = null;
-        } else {
-          _encryptionError = 'Failed to import backup: $e';
-        }
+        _encryptionError = 'Failed to import backup: $e';
         _isLoading = false;
         notifyListeners();
         return false;
@@ -672,6 +691,7 @@ class OtpState extends ChangeNotifier {
   }
 
   Future<void> migratePlaintextDataToEncryptedVault(String password) async {
+    _debouncedSaveTimer?.cancel();
     await _runBusyOperation(BusyOperation.encryptingLocalData, () async {
       final data = AppData(services: _services, groups: _groups);
       await _storageRepository.migratePlaintextDataToEncryptedVault(
@@ -680,6 +700,7 @@ class OtpState extends ChangeNotifier {
       );
       _activeStorageSource = StorageDataSource.encryptedVault;
       _localVaultPassword = password;
+      await _cacheVaultSessionKey(password);
       _shouldPromptForEncryptionMigration = false;
       _hasExistingData = true;
       notifyListeners();
@@ -691,14 +712,17 @@ class OtpState extends ChangeNotifier {
       throw StateError('Encrypted local storage is not active');
     }
 
+    _debouncedSaveTimer?.cancel();
     await _runBusyOperation(BusyOperation.changingVaultPassword, () async {
       final data = AppData(services: _services, groups: _groups);
       await _storageRepository.saveData(
         data,
         source: StorageDataSource.encryptedVault,
         password: password,
+        verify: true,
       );
       _localVaultPassword = password;
+      await _cacheVaultSessionKey(password);
       notifyListeners();
     });
   }
@@ -720,6 +744,9 @@ class OtpState extends ChangeNotifier {
     _activeStorageSource = result.source;
     _localVaultPassword =
         result.source == StorageDataSource.encryptedVault ? password : null;
+    if (result.source != StorageDataSource.encryptedVault) {
+      _clearVaultSessionKey();
+    }
     _shouldPromptForEncryptionMigration =
         result.source == StorageDataSource.plaintextJson &&
             (_services.isNotEmpty || _groups.isNotEmpty);
@@ -733,16 +760,54 @@ class OtpState extends ChangeNotifier {
 
     _activeStorageSource = StorageDataSource.plaintextJson;
     _localVaultPassword = null;
+    _clearVaultSessionKey();
     _shouldPromptForEncryptionMigration =
         _services.isNotEmpty || _groups.isNotEmpty;
   }
 
   Future<void> _persistCurrentData() async {
     final data = AppData(services: _services, groups: _groups);
+
+    if (_activeStorageSource == StorageDataSource.encryptedVault &&
+        _vaultKey != null &&
+        _vaultSalt != null &&
+        _vaultIterations != null) {
+      await _storageRepository.saveEncryptedDataWithKey(
+        data,
+        _vaultKey!,
+        salt: _vaultSalt!,
+        iterations: _vaultIterations!,
+      );
+      await _storageRepository.deletePlaintextData();
+      return;
+    }
+
     await _storageRepository.saveData(
       data,
       source: _activeStorageSource,
       password: _localVaultPassword,
     );
+  }
+
+  Future<void> _cacheVaultSessionKey(String password) async {
+    try {
+      final params = await _storageRepository.readVaultKdfParameters();
+      _vaultKey = await LocalVaultEncryptionService.deriveKey(
+        password,
+        params.salt,
+        params.iterations,
+      );
+      _vaultSalt = params.salt;
+      _vaultIterations = params.iterations;
+    } catch (e) {
+      debugPrint('Could not cache vault session key: $e');
+      _clearVaultSessionKey();
+    }
+  }
+
+  void _clearVaultSessionKey() {
+    _vaultKey = null;
+    _vaultSalt = null;
+    _vaultIterations = null;
   }
 }

--- a/lib/presentation/state/otp_state.dart
+++ b/lib/presentation/state/otp_state.dart
@@ -52,6 +52,7 @@ class OtpState extends ChangeNotifier {
   bool _dataInitialized = false;
   PasswordPromptReason _passwordPromptReason = PasswordPromptReason.none;
   bool _shouldPromptForEncryptionMigration = false;
+  bool _encryptionMigrationDismissed = false;
   StorageDataSource _activeStorageSource = StorageDataSource.none;
   String? _localVaultPassword;
   Uint8List? _vaultKey;
@@ -260,11 +261,13 @@ class OtpState extends ChangeNotifier {
         AppConfig.getDisplayMode().catchError((_) => DisplayMode.grouped),
         _storageRepository.getLocalFile(),
         _storageRepository.hasExistingData(),
+        AppConfig.getEncryptionMigrationDismissed().catchError((_) => false),
       ]);
       _displayMode = results[0] as DisplayMode;
       final file = results[1] as File;
       _dataDirectory = file.parent.path;
       _hasExistingData = results[2] as bool;
+      _encryptionMigrationDismissed = results[3] as bool;
 
       // Yield after file system access to keep UI responsive
       if (withUIYields) await _yieldToUI(16);
@@ -368,6 +371,10 @@ class OtpState extends ChangeNotifier {
   }
 
   void dismissEncryptionMigrationPrompt() {
+    _encryptionMigrationDismissed = true;
+    AppConfig.setEncryptionMigrationDismissed(true).catchError((e) {
+      debugPrint('Could not persist encryption migration dismissal: $e');
+    });
     if (!_shouldPromptForEncryptionMigration) {
       return;
     }
@@ -747,9 +754,9 @@ class OtpState extends ChangeNotifier {
     if (result.source != StorageDataSource.encryptedVault) {
       _clearVaultSessionKey();
     }
-    _shouldPromptForEncryptionMigration =
+    _shouldPromptForEncryptionMigration = !_encryptionMigrationDismissed &&
         result.source == StorageDataSource.plaintextJson &&
-            (_services.isNotEmpty || _groups.isNotEmpty);
+        (_services.isNotEmpty || _groups.isNotEmpty);
   }
 
   void _setStorageModeAfterImport() {
@@ -761,8 +768,8 @@ class OtpState extends ChangeNotifier {
     _activeStorageSource = StorageDataSource.plaintextJson;
     _localVaultPassword = null;
     _clearVaultSessionKey();
-    _shouldPromptForEncryptionMigration =
-        _services.isNotEmpty || _groups.isNotEmpty;
+    _shouldPromptForEncryptionMigration = !_encryptionMigrationDismissed &&
+        (_services.isNotEmpty || _groups.isNotEmpty);
   }
 
   Future<void> _persistCurrentData() async {

--- a/lib/presentation/state/otp_state.dart
+++ b/lib/presentation/state/otp_state.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import '../../config/app_config.dart';
@@ -9,10 +8,22 @@ import '../../data/models/group.dart';
 import '../../data/repositories/storage_repository.dart';
 import '../../domain/services/otp_service.dart';
 import '../../utils/clipboard_utils.dart';
-import '../../services/twofas_decryption_service.dart';
 import '../../services/secure_storage_service.dart';
 import '../../services/twofas_icon_service.dart';
 import 'otp_display_state.dart';
+
+enum PasswordPromptReason {
+  none,
+  encryptedVault,
+  encryptedBackup,
+}
+
+enum BusyOperation {
+  unlockingVault,
+  decryptingBackup,
+  encryptingLocalData,
+  changingVaultPassword,
+}
 
 class OtpState extends ChangeNotifier {
   final StorageRepository _storageRepository;
@@ -36,11 +47,41 @@ class OtpState extends ChangeNotifier {
   String? _selectedFilePath;
   DisplayMode _displayMode = DisplayMode.grouped;
   bool _dataInitialized = false;
+  PasswordPromptReason _passwordPromptReason = PasswordPromptReason.none;
+  bool _shouldPromptForEncryptionMigration = false;
+  StorageDataSource _activeStorageSource = StorageDataSource.none;
+  String? _localVaultPassword;
+  BusyOperation? _busyOperation;
 
   // Helper method to yield control to allow UI updates
   Future<void> _yieldToUI([int milliseconds = 16]) async {
     // Give enough time for multiple UI frames - tests will pump through these quickly
     await Future.delayed(Duration(milliseconds: milliseconds));
+  }
+
+  Future<T> _runBusyOperation<T>(
+    BusyOperation operation,
+    Future<T> Function() action,
+  ) async {
+    final changedOperation = _busyOperation != operation;
+    if (changedOperation) {
+      _busyOperation = operation;
+      if (!_disposed) {
+        notifyListeners();
+      }
+      await _yieldToUI();
+    }
+
+    try {
+      return await action();
+    } finally {
+      if (_busyOperation == operation) {
+        _busyOperation = null;
+        if (!_disposed) {
+          notifyListeners();
+        }
+      }
+    }
   }
 
   /// Creates a new OtpState instance.
@@ -71,10 +112,36 @@ class OtpState extends ChangeNotifier {
   String get dataDirectory => _dataDirectory;
   bool get isLoading => _isLoading;
   bool get requiresPassword => _requiresPassword;
+  bool get requiresLocalVaultPassword =>
+      _passwordPromptReason == PasswordPromptReason.encryptedVault;
+  bool get requiresBackupPassword =>
+      _passwordPromptReason == PasswordPromptReason.encryptedBackup;
   String? get encryptionError => _encryptionError;
   bool get hasExistingData => _hasExistingData;
   String? get selectedFilePath => _selectedFilePath;
   DisplayMode get displayMode => _displayMode;
+  bool get shouldPromptForEncryptionMigration =>
+      _shouldPromptForEncryptionMigration;
+  bool get usesEncryptedLocalStorage =>
+      _activeStorageSource == StorageDataSource.encryptedVault;
+  bool get canEncryptLocalData =>
+      !usesEncryptedLocalStorage &&
+      (_services.isNotEmpty || _groups.isNotEmpty);
+  bool get isBusy => _busyOperation != null;
+  String? get busyMessage {
+    switch (_busyOperation) {
+      case BusyOperation.unlockingVault:
+        return 'Unlocking encrypted vault...';
+      case BusyOperation.decryptingBackup:
+        return 'Decrypting encrypted backup...';
+      case BusyOperation.encryptingLocalData:
+        return 'Encrypting local data...';
+      case BusyOperation.changingVaultPassword:
+        return 'Updating vault password...';
+      case null:
+        return null;
+    }
+  }
 
   OtpDisplayState getOtpDisplayState(String serviceKey) {
     return _otpDisplayStates[serviceKey] ?? OtpDisplayState.empty;
@@ -113,9 +180,7 @@ class OtpState extends ChangeNotifier {
     // Schedule a new save after 2 seconds of inactivity
     _debouncedSaveTimer = Timer(const Duration(seconds: 2), () async {
       try {
-        await _storageRepository.saveData(
-          AppData(services: _services, groups: _groups),
-        );
+        await _persistCurrentData();
         debugPrint('Usage data saved successfully');
       } catch (e) {
         debugPrint('Error saving usage data: $e');
@@ -139,6 +204,7 @@ class OtpState extends ChangeNotifier {
     _isLoading = true;
     _requiresPassword = false;
     _encryptionError = null;
+    _passwordPromptReason = PasswordPromptReason.none;
     if (!_disposed) {
       notifyListeners();
     }
@@ -169,6 +235,7 @@ class OtpState extends ChangeNotifier {
     _isLoading = true;
     _requiresPassword = false;
     _encryptionError = null;
+    _passwordPromptReason = PasswordPromptReason.none;
     if (!_disposed) {
       notifyListeners();
     }
@@ -192,71 +259,37 @@ class OtpState extends ChangeNotifier {
       // Yield after file system access to keep UI responsive
       if (withUIYields) await _yieldToUI(16);
 
-      if (await file.exists()) {
-        final contents = await file.readAsString();
+      final result = await _storageRepository.loadStoredData();
 
-        // Yield after file read to keep UI responsive
-        if (withUIYields) await _yieldToUI(24);
+      if (withUIYields) await _yieldToUI(24);
 
-        final jsonData = jsonDecode(contents) as Map<String, dynamic>;
-
-        // Yield after JSON parsing to keep UI responsive
-        if (withUIYields) await _yieldToUI(16);
-
-        if (TwoFasDecryptionService.isEncrypted(jsonData)) {
-          // Try to load with stored password first
-          try {
-            final data = await _storageRepository.loadData();
-
-            // Yield after secure storage access to keep UI responsive
-            if (withUIYields) await _yieldToUI(32);
-
-            _services = data.services;
-            _groups = data.groups;
-
-            // Yield before data processing to keep UI responsive
-            if (withUIYields) await _yieldToUI(16);
-
-            _groupedServices = _groupServicesByGroup();
-            _isLoading = false;
-            if (!_disposed) {
-              notifyListeners();
-            }
-
-            // Preload icons for imported services asynchronously
-            _preloadIconsForServices();
-
-            return;
-          } catch (e) {
-            // If stored password failed, require manual password entry
-            if (e.toString().contains('Password required')) {
-              _requiresPassword = true;
-              _isLoading = false;
-              if (!_disposed) {
-                notifyListeners();
-              }
-              return;
-            } else {
-              // Other errors (like wrong stored password) should be handled
-              _encryptionError = 'Failed to decrypt backup: ${e.toString()}';
-              _requiresPassword = true;
-              _isLoading = false;
-              if (!_disposed) {
-                notifyListeners();
-              }
-              return;
-            }
-          }
-        }
-      }
-
-      final data = await _storageRepository.loadData();
-      _services = data.services;
-      _groups = data.groups;
+      _applyLoadedData(result);
       _groupedServices = _groupServicesByGroup();
 
       // Preload icons for imported services asynchronously
       _preloadIconsForServices();
+    } on StoragePasswordRequiredException catch (e) {
+      _requiresPassword = true;
+      _passwordPromptReason = e.source == StorageDataSource.encryptedVault
+          ? PasswordPromptReason.encryptedVault
+          : PasswordPromptReason.encryptedBackup;
+      _isLoading = false;
+      if (!_disposed) {
+        notifyListeners();
+      }
+      return;
+    } on StorageLoadException catch (e) {
+      _requiresPassword = true;
+      _passwordPromptReason = e.source == StorageDataSource.encryptedVault
+          ? PasswordPromptReason.encryptedVault
+          : PasswordPromptReason.encryptedBackup;
+      _encryptionError = e.toString();
+      debugPrint(_encryptionError);
+      _isLoading = false;
+      if (!_disposed) {
+        notifyListeners();
+      }
+      return;
     } catch (e) {
       _encryptionError = 'Error loading data: $e';
       debugPrint(_encryptionError);
@@ -274,19 +307,39 @@ class OtpState extends ChangeNotifier {
     _encryptionError = null;
     notifyListeners();
 
-    try {
-      final data = await _storageRepository.loadData(password: password);
-      _services = data.services;
-      _groups = data.groups;
-      _groupedServices = _groupServicesByGroup();
-      _requiresPassword = false;
+    final busyOperation =
+        _passwordPromptReason == PasswordPromptReason.encryptedVault
+            ? BusyOperation.unlockingVault
+            : BusyOperation.decryptingBackup;
 
-      // Preload icons for imported services asynchronously
-      _preloadIconsForServices();
-    } catch (e) {
-      _encryptionError = e.toString();
-      debugPrint('Error loading encrypted data: $e');
-    }
+    await _runBusyOperation(busyOperation, () async {
+      try {
+        final result =
+            await _storageRepository.loadStoredData(password: password);
+        _applyLoadedData(result, password: password);
+        _groupedServices = _groupServicesByGroup();
+        _requiresPassword = false;
+        _passwordPromptReason = PasswordPromptReason.none;
+
+        // Preload icons for imported services asynchronously
+        _preloadIconsForServices();
+      } on StoragePasswordRequiredException catch (e) {
+        _requiresPassword = true;
+        _passwordPromptReason = e.source == StorageDataSource.encryptedVault
+            ? PasswordPromptReason.encryptedVault
+            : PasswordPromptReason.encryptedBackup;
+      } on StorageLoadException catch (e) {
+        _encryptionError = e.toString();
+        _requiresPassword = true;
+        _passwordPromptReason = e.source == StorageDataSource.encryptedVault
+            ? PasswordPromptReason.encryptedVault
+            : PasswordPromptReason.encryptedBackup;
+        debugPrint('Error loading encrypted data: $e');
+      } catch (e) {
+        _encryptionError = e.toString();
+        debugPrint('Error loading encrypted data: $e');
+      }
+    });
 
     _isLoading = false;
     notifyListeners();
@@ -296,11 +349,20 @@ class OtpState extends ChangeNotifier {
     initializeData();
   }
 
+  void dismissEncryptionMigrationPrompt() {
+    if (!_shouldPromptForEncryptionMigration) {
+      return;
+    }
+    _shouldPromptForEncryptionMigration = false;
+    notifyListeners();
+  }
+
   Future<void> clearStoredPassword() async {
     try {
       await SecureStorageService.clearStoredPassword();
       _requiresPassword = true;
       _encryptionError = null;
+      _passwordPromptReason = PasswordPromptReason.encryptedBackup;
       notifyListeners();
     } catch (e) {
       debugPrint('Error clearing stored password: $e');
@@ -547,32 +609,50 @@ class OtpState extends ChangeNotifier {
     _encryptionError = null;
     notifyListeners();
 
-    try {
-      final data = await _storageRepository.importBackupFile(filePath,
-          password: password);
-      _services = data.services;
-      _groups = data.groups;
-      _groupedServices = _groupServicesByGroup();
-      _hasExistingData = true;
-      _requiresPassword = false;
-      _isLoading = false;
-      notifyListeners();
+    final busyOperation = password != null
+        ? BusyOperation.decryptingBackup
+        : usesEncryptedLocalStorage
+            ? BusyOperation.encryptingLocalData
+            : null;
 
-      // Preload icons for imported services asynchronously
-      _preloadIconsForServices();
+    Future<bool> performImport() async {
+      try {
+        final data = await _storageRepository.importBackupFile(filePath,
+            password: password);
+        _services = data.services;
+        _groups = data.groups;
+        _setStorageModeAfterImport();
+        _groupedServices = _groupServicesByGroup();
+        _hasExistingData = true;
+        _requiresPassword = false;
+        _passwordPromptReason = PasswordPromptReason.none;
+        _isLoading = false;
+        await _persistCurrentData();
+        notifyListeners();
 
-      return true;
-    } catch (e) {
-      if (e.toString().contains('Password required')) {
-        _requiresPassword = true;
-        _encryptionError = null;
-      } else {
-        _encryptionError = 'Failed to import backup: $e';
+        // Preload icons for imported services asynchronously
+        _preloadIconsForServices();
+
+        return true;
+      } catch (e) {
+        if (e.toString().contains('Password required')) {
+          _requiresPassword = true;
+          _passwordPromptReason = PasswordPromptReason.encryptedBackup;
+          _encryptionError = null;
+        } else {
+          _encryptionError = 'Failed to import backup: $e';
+        }
+        _isLoading = false;
+        notifyListeners();
+        return false;
       }
-      _isLoading = false;
-      notifyListeners();
-      return false;
     }
+
+    if (busyOperation == null) {
+      return performImport();
+    }
+
+    return _runBusyOperation(busyOperation, performImport);
   }
 
   /// Reimports data by opening file picker and importing selected file
@@ -591,6 +671,38 @@ class OtpState extends ChangeNotifier {
     return await importBackupFile(_selectedFilePath!, password: password);
   }
 
+  Future<void> migratePlaintextDataToEncryptedVault(String password) async {
+    await _runBusyOperation(BusyOperation.encryptingLocalData, () async {
+      final data = AppData(services: _services, groups: _groups);
+      await _storageRepository.migratePlaintextDataToEncryptedVault(
+        data,
+        password,
+      );
+      _activeStorageSource = StorageDataSource.encryptedVault;
+      _localVaultPassword = password;
+      _shouldPromptForEncryptionMigration = false;
+      _hasExistingData = true;
+      notifyListeners();
+    });
+  }
+
+  Future<void> changeLocalVaultPassword(String password) async {
+    if (!usesEncryptedLocalStorage) {
+      throw StateError('Encrypted local storage is not active');
+    }
+
+    await _runBusyOperation(BusyOperation.changingVaultPassword, () async {
+      final data = AppData(services: _services, groups: _groups);
+      await _storageRepository.saveData(
+        data,
+        source: StorageDataSource.encryptedVault,
+        password: password,
+      );
+      _localVaultPassword = password;
+      notifyListeners();
+    });
+  }
+
   /// Preloads icons for the current services asynchronously
   void _preloadIconsForServices() {
     if (_services.isEmpty) return;
@@ -600,5 +712,37 @@ class OtpState extends ChangeNotifier {
 
     // Preload icons in the background (non-blocking)
     TwoFasIconService.preloadIconsForServices(serviceNames, issuers);
+  }
+
+  void _applyLoadedData(LoadedAppData result, {String? password}) {
+    _services = result.data.services;
+    _groups = result.data.groups;
+    _activeStorageSource = result.source;
+    _localVaultPassword =
+        result.source == StorageDataSource.encryptedVault ? password : null;
+    _shouldPromptForEncryptionMigration =
+        result.source == StorageDataSource.plaintextJson &&
+            (_services.isNotEmpty || _groups.isNotEmpty);
+  }
+
+  void _setStorageModeAfterImport() {
+    if (_activeStorageSource == StorageDataSource.encryptedVault) {
+      _shouldPromptForEncryptionMigration = false;
+      return;
+    }
+
+    _activeStorageSource = StorageDataSource.plaintextJson;
+    _localVaultPassword = null;
+    _shouldPromptForEncryptionMigration =
+        _services.isNotEmpty || _groups.isNotEmpty;
+  }
+
+  Future<void> _persistCurrentData() async {
+    final data = AppData(services: _services, groups: _groups);
+    await _storageRepository.saveData(
+      data,
+      source: _activeStorageSource,
+      password: _localVaultPassword,
+    );
   }
 }

--- a/lib/presentation/widgets/password_dialog.dart
+++ b/lib/presentation/widgets/password_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../data/repositories/storage_repository.dart';
+
 enum PasswordDialogMode {
   unlockVault,
   decryptBackup,
@@ -10,11 +12,13 @@ enum PasswordDialogMode {
 class PasswordDialog extends StatefulWidget {
   final PasswordDialogMode mode;
   final String? errorMessage;
+  final VaultLoadErrorKind? errorKind;
 
   const PasswordDialog({
     super.key,
     required this.mode,
     this.errorMessage,
+    this.errorKind,
   });
 
   @override
@@ -254,36 +258,26 @@ class _PasswordDialogState extends State<PasswordDialog> {
     if (_validationError != null) {
       return _validationError;
     }
-    if (widget.errorMessage == null) {
-      return null;
-    }
-    return _mapErrorMessage(widget.errorMessage!);
-  }
 
-  String _mapErrorMessage(String error) {
     if (_requiresConfirmation) {
+      if (widget.errorMessage == null && widget.errorKind == null) {
+        return null;
+      }
       return 'An error occurred while creating the encrypted vault. Please try again.';
     }
 
-    if (error.contains('Invalid password') ||
-        error.contains('Decryption failed') ||
-        error.contains('Failed to unlock encrypted vault') ||
-        error.contains('Invalid password or corrupted encrypted vault')) {
-      return 'Incorrect password. Please try again.';
+    switch (widget.errorKind) {
+      case VaultLoadErrorKind.corruptedVault:
+        return 'This vault file appears to be corrupted or was created by a newer version.';
+      case VaultLoadErrorKind.incorrectPassword:
+        return 'Incorrect password. Please try again.';
+      case VaultLoadErrorKind.unknown:
+      case null:
+        break;
     }
 
-    if (error.contains('Invalid encrypted vault file') ||
-        error.contains('Invalid encrypted vault format')) {
-      return 'This encrypted vault appears to be corrupted or invalid.';
-    }
-
-    if (error.contains('Invalid vault file') ||
-        error.contains('Invalid encrypted backup format')) {
-      return 'This backup file appears to be corrupted or invalid.';
-    }
-
-    if (error.contains('Password required')) {
-      return _modeNameForMissingPassword();
+    if (widget.errorMessage == null) {
+      return null;
     }
 
     if (widget.mode == PasswordDialogMode.unlockVault) {

--- a/lib/presentation/widgets/password_dialog.dart
+++ b/lib/presentation/widgets/password_dialog.dart
@@ -1,9 +1,21 @@
 import 'package:flutter/material.dart';
 
+enum PasswordDialogMode {
+  unlockVault,
+  decryptBackup,
+  createVaultPassword,
+  changeVaultPassword,
+}
+
 class PasswordDialog extends StatefulWidget {
+  final PasswordDialogMode mode;
   final String? errorMessage;
 
-  const PasswordDialog({super.key, this.errorMessage});
+  const PasswordDialog({
+    super.key,
+    required this.mode,
+    this.errorMessage,
+  });
 
   @override
   State<PasswordDialog> createState() => _PasswordDialogState();
@@ -11,33 +23,42 @@ class PasswordDialog extends StatefulWidget {
 
 class _PasswordDialogState extends State<PasswordDialog> {
   final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
   bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
   bool _isLoading = false;
+  String? _validationError;
+
+  bool get _requiresConfirmation =>
+      widget.mode == PasswordDialogMode.createVaultPassword ||
+      widget.mode == PasswordDialogMode.changeVaultPassword;
 
   @override
   void dispose() {
     _passwordController.dispose();
+    _confirmPasswordController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return AlertDialog(
-      title: const Text('Encrypted Backup Detected'),
+      title: Text(_titleText()),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'This backup file is encrypted. Please enter the password to decrypt it.',
-          ),
+          Text(_descriptionText()),
           const SizedBox(height: 16),
           TextField(
             controller: _passwordController,
             obscureText: _obscurePassword,
             enabled: !_isLoading,
+            autofocus: true,
             decoration: InputDecoration(
-              labelText: 'Password',
+              labelText: _requiresConfirmation ? 'New Password' : 'Password',
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
                 icon: Icon(
@@ -50,35 +71,67 @@ class _PasswordDialogState extends State<PasswordDialog> {
                 },
               ),
             ),
+            onChanged: _clearValidationError,
             onSubmitted: _isLoading ? null : (_) => _submitPassword(),
           ),
-          if (widget.errorMessage != null) ...[
+          if (_requiresConfirmation) ...[
+            const SizedBox(height: 12),
+            TextField(
+              controller: _confirmPasswordController,
+              obscureText: _obscureConfirmPassword,
+              enabled: !_isLoading,
+              decoration: InputDecoration(
+                labelText: 'Confirm Password',
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureConfirmPassword
+                        ? Icons.visibility
+                        : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscureConfirmPassword = !_obscureConfirmPassword;
+                    });
+                  },
+                ),
+              ),
+              onChanged: _clearValidationError,
+              onSubmitted: _isLoading ? null : (_) => _submitPassword(),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Use a strong password you can remember. If you lose it, the encrypted local data cannot be recovered.',
+              style: TextStyle(
+                fontSize: 12,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+          if (_effectiveErrorMessage() != null) ...[
             const SizedBox(height: 12),
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.errorContainer,
+                color: colorScheme.errorContainer,
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .error
-                      .withValues(alpha: 0.3),
+                  color: colorScheme.error.withValues(alpha: 0.3),
                 ),
               ),
               child: Row(
                 children: [
                   Icon(
                     Icons.error_outline,
-                    color: Theme.of(context).colorScheme.error,
+                    color: colorScheme.error,
                     size: 20,
                   ),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      _getErrorMessage(widget.errorMessage!),
+                      _effectiveErrorMessage()!,
                       style: TextStyle(
-                        color: Theme.of(context).colorScheme.onErrorContainer,
+                        color: colorScheme.onErrorContainer,
                         fontSize: 14,
                       ),
                     ),
@@ -102,7 +155,7 @@ class _PasswordDialogState extends State<PasswordDialog> {
                   height: 16,
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
-              : const Text('Decrypt'),
+              : Text(_submitButtonText()),
         ),
       ],
     );
@@ -110,26 +163,133 @@ class _PasswordDialogState extends State<PasswordDialog> {
 
   void _submitPassword() {
     final password = _passwordController.text.trim();
-    if (password.isEmpty) return;
+    final confirmPassword = _confirmPasswordController.text.trim();
+
+    if (password.isEmpty) {
+      setState(() {
+        _validationError = _requiresConfirmation
+            ? 'A password is required to create the encrypted vault.'
+            : _modeNameForMissingPassword();
+      });
+      return;
+    }
+
+    if (_requiresConfirmation && password != confirmPassword) {
+      setState(() {
+        _validationError = 'Passwords do not match. Please try again.';
+      });
+      return;
+    }
 
     setState(() {
       _isLoading = true;
+      _validationError = null;
     });
 
     Navigator.of(context).pop(password);
   }
 
-  String _getErrorMessage(String error) {
+  void _clearValidationError(String _) {
+    if (_validationError == null) {
+      return;
+    }
+    setState(() {
+      _validationError = null;
+    });
+  }
+
+  String _titleText() {
+    switch (widget.mode) {
+      case PasswordDialogMode.unlockVault:
+        return 'Encrypted Vault Detected';
+      case PasswordDialogMode.decryptBackup:
+        return 'Encrypted Backup Detected';
+      case PasswordDialogMode.createVaultPassword:
+        return 'Create Vault Password';
+      case PasswordDialogMode.changeVaultPassword:
+        return 'Change Vault Password';
+    }
+  }
+
+  String _descriptionText() {
+    switch (widget.mode) {
+      case PasswordDialogMode.unlockVault:
+        return 'This local vault is encrypted. Enter the password to unlock your stored services.';
+      case PasswordDialogMode.decryptBackup:
+        return 'This backup file is encrypted. Enter the password to decrypt it.';
+      case PasswordDialogMode.createVaultPassword:
+        return 'Choose a password for the encrypted local vault.';
+      case PasswordDialogMode.changeVaultPassword:
+        return 'Choose a new password for the encrypted local vault.';
+    }
+  }
+
+  String _submitButtonText() {
+    switch (widget.mode) {
+      case PasswordDialogMode.unlockVault:
+        return 'Unlock';
+      case PasswordDialogMode.decryptBackup:
+        return 'Decrypt';
+      case PasswordDialogMode.createVaultPassword:
+        return 'Create Vault';
+      case PasswordDialogMode.changeVaultPassword:
+        return 'Change Password';
+    }
+  }
+
+  String _modeNameForMissingPassword() {
+    switch (widget.mode) {
+      case PasswordDialogMode.unlockVault:
+        return 'A password is required to unlock this vault.';
+      case PasswordDialogMode.decryptBackup:
+        return 'A password is required to decrypt this backup.';
+      case PasswordDialogMode.createVaultPassword:
+        return 'A password is required to create the encrypted vault.';
+      case PasswordDialogMode.changeVaultPassword:
+        return 'A password is required to change the encrypted vault password.';
+    }
+  }
+
+  String? _effectiveErrorMessage() {
+    if (_validationError != null) {
+      return _validationError;
+    }
+    if (widget.errorMessage == null) {
+      return null;
+    }
+    return _mapErrorMessage(widget.errorMessage!);
+  }
+
+  String _mapErrorMessage(String error) {
+    if (_requiresConfirmation) {
+      return 'An error occurred while creating the encrypted vault. Please try again.';
+    }
+
     if (error.contains('Invalid password') ||
-        error.contains('Decryption failed')) {
+        error.contains('Decryption failed') ||
+        error.contains('Failed to unlock encrypted vault') ||
+        error.contains('Invalid password or corrupted encrypted vault')) {
       return 'Incorrect password. Please try again.';
-    } else if (error.contains('Invalid vault file') ||
+    }
+
+    if (error.contains('Invalid encrypted vault file') ||
+        error.contains('Invalid encrypted vault format')) {
+      return 'This encrypted vault appears to be corrupted or invalid.';
+    }
+
+    if (error.contains('Invalid vault file') ||
         error.contains('Invalid encrypted backup format')) {
       return 'This backup file appears to be corrupted or invalid.';
-    } else if (error.contains('Password required')) {
-      return 'A password is required to decrypt this backup.';
-    } else {
-      return 'An error occurred while decrypting the backup. Please try again.';
     }
+
+    if (error.contains('Password required')) {
+      return _modeNameForMissingPassword();
+    }
+
+    if (widget.mode == PasswordDialogMode.unlockVault) {
+      return 'An error occurred while unlocking the vault. Please try again.';
+    }
+
+    return 'An error occurred while decrypting the backup. Please try again.';
   }
 }

--- a/lib/services/crypto_primitives.dart
+++ b/lib/services/crypto_primitives.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart';
+
+Uint8List derivePbkdf2HmacSha256Key(
+  String password,
+  Uint8List salt,
+  int iterations,
+  int keyLength,
+) {
+  final pbkdf2 = PBKDF2KeyDerivator(HMac(SHA256Digest(), 64));
+  pbkdf2.init(Pbkdf2Parameters(salt, iterations, keyLength));
+  return pbkdf2.process(Uint8List.fromList(utf8.encode(password)));
+}
+
+Uint8List aesGcmEncrypt(
+  Uint8List key,
+  Uint8List nonce,
+  Uint8List plaintext,
+  Uint8List aad,
+  int tagLengthBytes,
+) {
+  final cipher = GCMBlockCipher(AESEngine());
+  cipher.init(
+    true,
+    AEADParameters(KeyParameter(key), tagLengthBytes * 8, nonce, aad),
+  );
+  return cipher.process(plaintext);
+}
+
+Uint8List aesGcmDecrypt(
+  Uint8List key,
+  Uint8List nonce,
+  Uint8List ciphertextWithTag,
+  Uint8List aad,
+  int tagLengthBytes,
+) {
+  final cipher = GCMBlockCipher(AESEngine());
+  cipher.init(
+    false,
+    AEADParameters(KeyParameter(key), tagLengthBytes * 8, nonce, aad),
+  );
+  return cipher.process(ciphertextWithTag);
+}

--- a/lib/services/local_vault_encryption_service.dart
+++ b/lib/services/local_vault_encryption_service.dart
@@ -1,0 +1,271 @@
+import 'dart:convert';
+import 'dart:isolate';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart';
+
+class LocalVaultEncryptionService {
+  static const String magic = 'LibreOTPVault';
+  static const int version = 1;
+  static const String kdfName = 'PBKDF2-HMAC-SHA256';
+  static const String cipherName = 'AES-256-GCM';
+  static const int keyLength = 32;
+  static const int saltLength = 32;
+  static const int nonceLength = 12;
+  static const int authTagLength = 16;
+  static const int defaultIterations = 210000;
+
+  static Future<Uint8List> encrypt(
+    String plaintextJson,
+    String password, {
+    int iterations = defaultIterations,
+  }) async {
+    return Isolate.run(
+      () => _encryptSync(
+        plaintextJson,
+        password,
+        iterations: iterations,
+      ),
+    );
+  }
+
+  static Uint8List _encryptSync(
+    String plaintextJson,
+    String password, {
+    required int iterations,
+  }) {
+    if (password.isEmpty) {
+      throw ArgumentError('Password required for encrypted vault');
+    }
+    if (iterations <= 0) {
+      throw ArgumentError('KDF iterations must be greater than zero');
+    }
+
+    final salt = _randomBytes(saltLength);
+    final nonce = _randomBytes(nonceLength);
+    final metadata = _metadata(
+      salt: salt,
+      nonce: nonce,
+      iterations: iterations,
+    );
+    final key = _deriveKey(password, salt, iterations);
+    final ciphertextWithTag = _encryptAesGcm(
+      utf8.encode(plaintextJson),
+      key,
+      nonce,
+      _authenticatedData(metadata),
+    );
+
+    final envelope = {
+      ...metadata,
+      'ciphertext': base64.encode(ciphertextWithTag),
+    };
+
+    return Uint8List.fromList(utf8.encode(jsonEncode(envelope)));
+  }
+
+  static Future<String> decrypt(
+    Uint8List vaultBytes,
+    String password,
+  ) async {
+    return Isolate.run(() => _decryptSync(vaultBytes, password));
+  }
+
+  static String _decryptSync(
+    Uint8List vaultBytes,
+    String password,
+  ) {
+    if (password.isEmpty) {
+      throw ArgumentError('Password required for encrypted vault');
+    }
+
+    final envelope = _decodeEnvelope(vaultBytes);
+    final metadata = _validateAndExtractMetadata(envelope);
+    final kdf = metadata['kdf'] as Map<String, dynamic>;
+    final cipher = metadata['cipher'] as Map<String, dynamic>;
+    final salt = base64.decode(kdf['salt'] as String);
+    final nonce = base64.decode(cipher['nonce'] as String);
+    final iterations = kdf['iterations'] as int;
+    final ciphertextWithTag = _readBase64String(
+      envelope,
+      'ciphertext',
+      'Invalid encrypted vault ciphertext',
+    );
+
+    final key = _deriveKey(password, salt, iterations);
+    final plaintext = _decryptAesGcm(
+      ciphertextWithTag,
+      key,
+      nonce,
+      _authenticatedData(metadata),
+    );
+
+    return utf8.decode(plaintext);
+  }
+
+  static Map<String, dynamic> _metadata({
+    required Uint8List salt,
+    required Uint8List nonce,
+    required int iterations,
+  }) {
+    return {
+      'magic': magic,
+      'version': version,
+      'kdf': {
+        'name': kdfName,
+        'salt': base64.encode(salt),
+        'iterations': iterations,
+        'keyLength': keyLength,
+      },
+      'cipher': {
+        'name': cipherName,
+        'nonce': base64.encode(nonce),
+        'tagLength': authTagLength,
+      },
+    };
+  }
+
+  static Map<String, dynamic> _decodeEnvelope(Uint8List vaultBytes) {
+    try {
+      final decoded = jsonDecode(utf8.decode(vaultBytes));
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('Invalid encrypted vault format');
+      }
+      return decoded;
+    } catch (e) {
+      if (e is FormatException) {
+        rethrow;
+      }
+      throw const FormatException('Invalid encrypted vault format');
+    }
+  }
+
+  static Map<String, dynamic> _validateAndExtractMetadata(
+    Map<String, dynamic> envelope,
+  ) {
+    if (envelope['magic'] != magic) {
+      throw const FormatException('Invalid encrypted vault file');
+    }
+    if (envelope['version'] != version) {
+      throw UnsupportedError('Unsupported encrypted vault version');
+    }
+
+    final kdf = envelope['kdf'];
+    final cipher = envelope['cipher'];
+    if (kdf is! Map<String, dynamic> || cipher is! Map<String, dynamic>) {
+      throw const FormatException('Invalid encrypted vault metadata');
+    }
+    if (kdf['name'] != kdfName) {
+      throw UnsupportedError('Unsupported encrypted vault KDF');
+    }
+    if (cipher['name'] != cipherName) {
+      throw UnsupportedError('Unsupported encrypted vault cipher');
+    }
+    if (kdf['iterations'] is! int || (kdf['iterations'] as int) <= 0) {
+      throw const FormatException('Invalid encrypted vault KDF iterations');
+    }
+    if (kdf['keyLength'] != keyLength) {
+      throw const FormatException('Invalid encrypted vault key length');
+    }
+    if (cipher['tagLength'] != authTagLength) {
+      throw const FormatException('Invalid encrypted vault auth tag length');
+    }
+
+    final salt = _readBase64String(kdf, 'salt', 'Invalid encrypted vault salt');
+    final nonce =
+        _readBase64String(cipher, 'nonce', 'Invalid encrypted vault nonce');
+    if (salt.length != saltLength) {
+      throw const FormatException('Invalid encrypted vault salt length');
+    }
+    if (nonce.length != nonceLength) {
+      throw const FormatException('Invalid encrypted vault nonce length');
+    }
+
+    return _metadata(
+      salt: salt,
+      nonce: nonce,
+      iterations: kdf['iterations'] as int,
+    );
+  }
+
+  static Uint8List _readBase64String(
+    Map<String, dynamic> source,
+    String key,
+    String errorMessage,
+  ) {
+    final value = source[key];
+    if (value is! String || value.isEmpty) {
+      throw FormatException(errorMessage);
+    }
+    try {
+      return base64.decode(value);
+    } catch (_) {
+      throw FormatException(errorMessage);
+    }
+  }
+
+  static Uint8List _authenticatedData(Map<String, dynamic> metadata) {
+    return Uint8List.fromList(utf8.encode(jsonEncode(metadata)));
+  }
+
+  static Uint8List _deriveKey(
+    String password,
+    Uint8List salt,
+    int iterations,
+  ) {
+    final pbkdf2 = PBKDF2KeyDerivator(HMac(SHA256Digest(), 64));
+    pbkdf2.init(Pbkdf2Parameters(salt, iterations, keyLength));
+    return pbkdf2.process(Uint8List.fromList(utf8.encode(password)));
+  }
+
+  static Uint8List _encryptAesGcm(
+    List<int> plaintext,
+    Uint8List key,
+    Uint8List nonce,
+    Uint8List authenticatedData,
+  ) {
+    final cipher = GCMBlockCipher(AESEngine());
+    final params = AEADParameters(
+      KeyParameter(key),
+      authTagLength * 8,
+      nonce,
+      authenticatedData,
+    );
+    cipher.init(true, params);
+    return cipher.process(Uint8List.fromList(plaintext));
+  }
+
+  static Uint8List _decryptAesGcm(
+    Uint8List ciphertextWithTag,
+    Uint8List key,
+    Uint8List nonce,
+    Uint8List authenticatedData,
+  ) {
+    if (ciphertextWithTag.length <= authTagLength) {
+      throw const FormatException('Invalid encrypted vault ciphertext length');
+    }
+
+    final cipher = GCMBlockCipher(AESEngine());
+    final params = AEADParameters(
+      KeyParameter(key),
+      authTagLength * 8,
+      nonce,
+      authenticatedData,
+    );
+    cipher.init(false, params);
+
+    try {
+      return cipher.process(ciphertextWithTag);
+    } catch (_) {
+      throw ArgumentError('Invalid password or corrupted encrypted vault');
+    }
+  }
+
+  static Uint8List _randomBytes(int length) {
+    final random = Random.secure();
+    return Uint8List.fromList(
+      List.generate(length, (_) => random.nextInt(256)),
+    );
+  }
+}

--- a/lib/services/local_vault_encryption_service.dart
+++ b/lib/services/local_vault_encryption_service.dart
@@ -3,7 +3,14 @@ import 'dart:isolate';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:pointycastle/export.dart';
+import 'crypto_primitives.dart';
+
+class VaultKdfParameters {
+  final Uint8List salt;
+  final int iterations;
+
+  const VaultKdfParameters({required this.salt, required this.iterations});
+}
 
 class LocalVaultEncryptionService {
   static const String magic = 'LibreOTPVault';
@@ -14,7 +21,8 @@ class LocalVaultEncryptionService {
   static const int saltLength = 32;
   static const int nonceLength = 12;
   static const int authTagLength = 16;
-  static const int defaultIterations = 210000;
+  static const int defaultIterations = 600000;
+  static const int maxIterations = 10000000;
 
   static Future<Uint8List> encrypt(
     String plaintextJson,
@@ -43,13 +51,59 @@ class LocalVaultEncryptionService {
     }
 
     final salt = _randomBytes(saltLength);
+    final key = _deriveKey(password, salt, iterations);
+    return _buildEnvelope(
+      plaintextJson,
+      key,
+      salt: salt,
+      iterations: iterations,
+    );
+  }
+
+  static Future<Uint8List> deriveKey(
+    String password,
+    Uint8List salt,
+    int iterations,
+  ) async {
+    return Isolate.run(() {
+      if (password.isEmpty) {
+        throw ArgumentError('Password required for encrypted vault');
+      }
+      if (iterations <= 0) {
+        throw ArgumentError('KDF iterations must be greater than zero');
+      }
+      return _deriveKey(password, salt, iterations);
+    });
+  }
+
+  static Future<Uint8List> encryptWithKey(
+    String plaintextJson,
+    Uint8List key, {
+    required Uint8List salt,
+    required int iterations,
+  }) async {
+    return Isolate.run(
+      () => _buildEnvelope(
+        plaintextJson,
+        key,
+        salt: salt,
+        iterations: iterations,
+      ),
+    );
+  }
+
+  static Uint8List _buildEnvelope(
+    String plaintextJson,
+    Uint8List key, {
+    required Uint8List salt,
+    required int iterations,
+  }) {
     final nonce = _randomBytes(nonceLength);
     final metadata = _metadata(
       salt: salt,
       nonce: nonce,
       iterations: iterations,
     );
-    final key = _deriveKey(password, salt, iterations);
     final ciphertextWithTag = _encryptAesGcm(
       utf8.encode(plaintextJson),
       key,
@@ -70,6 +124,16 @@ class LocalVaultEncryptionService {
     String password,
   ) async {
     return Isolate.run(() => _decryptSync(vaultBytes, password));
+  }
+
+  static VaultKdfParameters readKdfParameters(Uint8List vaultBytes) {
+    final envelope = _decodeEnvelope(vaultBytes);
+    final metadata = _validateAndExtractMetadata(envelope);
+    final kdf = metadata['kdf'] as Map<String, dynamic>;
+    return VaultKdfParameters(
+      salt: base64.decode(kdf['salt'] as String),
+      iterations: kdf['iterations'] as int,
+    );
   }
 
   static String _decryptSync(
@@ -162,7 +226,9 @@ class LocalVaultEncryptionService {
     if (cipher['name'] != cipherName) {
       throw UnsupportedError('Unsupported encrypted vault cipher');
     }
-    if (kdf['iterations'] is! int || (kdf['iterations'] as int) <= 0) {
+    if (kdf['iterations'] is! int ||
+        (kdf['iterations'] as int) <= 0 ||
+        (kdf['iterations'] as int) > maxIterations) {
       throw const FormatException('Invalid encrypted vault KDF iterations');
     }
     if (kdf['keyLength'] != keyLength) {
@@ -214,9 +280,7 @@ class LocalVaultEncryptionService {
     Uint8List salt,
     int iterations,
   ) {
-    final pbkdf2 = PBKDF2KeyDerivator(HMac(SHA256Digest(), 64));
-    pbkdf2.init(Pbkdf2Parameters(salt, iterations, keyLength));
-    return pbkdf2.process(Uint8List.fromList(utf8.encode(password)));
+    return derivePbkdf2HmacSha256Key(password, salt, iterations, keyLength);
   }
 
   static Uint8List _encryptAesGcm(
@@ -225,15 +289,13 @@ class LocalVaultEncryptionService {
     Uint8List nonce,
     Uint8List authenticatedData,
   ) {
-    final cipher = GCMBlockCipher(AESEngine());
-    final params = AEADParameters(
-      KeyParameter(key),
-      authTagLength * 8,
+    return aesGcmEncrypt(
+      key,
       nonce,
+      Uint8List.fromList(plaintext),
       authenticatedData,
+      authTagLength,
     );
-    cipher.init(true, params);
-    return cipher.process(Uint8List.fromList(plaintext));
   }
 
   static Uint8List _decryptAesGcm(
@@ -242,21 +304,18 @@ class LocalVaultEncryptionService {
     Uint8List nonce,
     Uint8List authenticatedData,
   ) {
-    if (ciphertextWithTag.length <= authTagLength) {
+    if (ciphertextWithTag.length < authTagLength) {
       throw const FormatException('Invalid encrypted vault ciphertext length');
     }
 
-    final cipher = GCMBlockCipher(AESEngine());
-    final params = AEADParameters(
-      KeyParameter(key),
-      authTagLength * 8,
-      nonce,
-      authenticatedData,
-    );
-    cipher.init(false, params);
-
     try {
-      return cipher.process(ciphertextWithTag);
+      return aesGcmDecrypt(
+        key,
+        nonce,
+        ciphertextWithTag,
+        authenticatedData,
+        authTagLength,
+      );
     } catch (_) {
       throw ArgumentError('Invalid password or corrupted encrypted vault');
     }

--- a/lib/services/twofas_decryption_service.dart
+++ b/lib/services/twofas_decryption_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
-import 'package:pointycastle/export.dart';
+
+import 'crypto_primitives.dart';
 
 class TwoFasDecryptionService {
   static const int _iterations = 10000;
@@ -34,7 +35,7 @@ class TwoFasDecryptionService {
     final salt = base64.decode(parts[1]);
     final iv = base64.decode(parts[2]);
 
-    if (cipherWithTag.length <= _authTagLength) {
+    if (cipherWithTag.length < _authTagLength) {
       throw FormatException('Invalid cipher data length');
     }
 
@@ -66,7 +67,7 @@ class TwoFasDecryptionService {
       final refCipherWithTag = base64.decode(referenceParts[0]);
       final refIv = base64.decode(referenceParts[2]);
 
-      if (refCipherWithTag.length <= _authTagLength) return false;
+      if (refCipherWithTag.length < _authTagLength) return false;
 
       final refCipherText =
           refCipherWithTag.sublist(0, refCipherWithTag.length - _authTagLength);
@@ -84,25 +85,17 @@ class TwoFasDecryptionService {
   }
 
   static Uint8List _deriveKey(String password, Uint8List salt) {
-    final pbkdf2 = PBKDF2KeyDerivator(HMac(SHA256Digest(), 64));
-    pbkdf2.init(Pbkdf2Parameters(salt, _iterations, _keyLength));
-    return pbkdf2.process(utf8.encode(password));
+    return derivePbkdf2HmacSha256Key(password, salt, _iterations, _keyLength);
   }
 
   static Uint8List _decryptAesGcm(
       Uint8List cipherText, Uint8List key, Uint8List iv, Uint8List authTag) {
-    final cipher = GCMBlockCipher(AESEngine());
-    final params =
-        AEADParameters(KeyParameter(key), authTag.length * 8, iv, Uint8List(0));
-
-    cipher.init(false, params);
-
     final input = Uint8List(cipherText.length + authTag.length);
     input.setRange(0, cipherText.length, cipherText);
     input.setRange(cipherText.length, input.length, authTag);
 
     try {
-      return cipher.process(input);
+      return aesGcmDecrypt(key, iv, input, Uint8List(0), authTag.length);
     } catch (e) {
       throw ArgumentError(
           'Decryption failed: Invalid password or corrupted data');

--- a/test/data/repositories/storage_repository_test.dart
+++ b/test/data/repositories/storage_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:libreotp/data/models/group.dart';
@@ -391,6 +392,35 @@ void main() {
                   (error) => error.message,
                   'message',
                   contains('Failed to unlock encrypted vault'),
+                )
+                .having(
+                  (error) => error.kind,
+                  'kind',
+                  VaultLoadErrorKind.incorrectPassword,
+                ),
+          ),
+        );
+      });
+
+      test('should report corrupted vault when data.bin is malformed',
+          () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final encryptedFile = await repository.getEncryptedLocalFile();
+        await encryptedFile.writeAsBytes(utf8.encode('not a vault envelope'));
+
+        expect(
+          () => repository.loadStoredData(password: 'any-password'),
+          throwsA(
+            isA<StorageLoadException>()
+                .having(
+                  (error) => error.source,
+                  'source',
+                  StorageDataSource.encryptedVault,
+                )
+                .having(
+                  (error) => error.kind,
+                  'kind',
+                  VaultLoadErrorKind.corruptedVault,
                 ),
           ),
         );

--- a/test/data/repositories/storage_repository_test.dart
+++ b/test/data/repositories/storage_repository_test.dart
@@ -1,13 +1,25 @@
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:libreotp/data/models/group.dart';
 import 'package:libreotp/data/models/otp_service.dart';
 import 'package:libreotp/data/repositories/storage_repository.dart';
+import 'package:libreotp/services/local_vault_encryption_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('StorageRepository', () {
-    setUp(() {});
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('libreotp_storage_test_');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
 
     group('Data models validation', () {
       test('should create valid Group from JSON', () {
@@ -178,6 +190,358 @@ void main() {
         // Test static properties without platform dependencies
         expect(StorageRepository, isA<Type>());
         // We can't test file paths in unit tests without mocking platform channels
+      });
+
+      test('should serialize and parse plaintext app data consistently', () {
+        final repository = StorageRepository();
+        final data = AppData(
+          services: const [
+            OtpService(
+              id: 'service-id',
+              name: 'GitHub',
+              secret: 'JBSWY3DPEHPK3PXP',
+              otp: OtpConfig(
+                account: 'dev@example.com',
+                issuer: 'GitHub',
+              ),
+              order: OrderInfo(position: 3),
+              groupId: 'group-id',
+            ),
+          ],
+          groups: const [
+            Group(id: 'group-id', name: 'Work'),
+          ],
+        );
+
+        final jsonString = repository.serializePlaintextAppData(data);
+        final decoded = repository.decodeJsonObject(jsonString);
+        final parsed = repository.parsePlaintextAppData(jsonString);
+
+        expect(decoded['services'], isA<List<dynamic>>());
+        expect(decoded['groups'], isA<List<dynamic>>());
+        expect(parsed.services, hasLength(1));
+        expect(parsed.groups, hasLength(1));
+        expect(parsed.services.first.id, equals('service-id'));
+        expect(parsed.services.first.secret, equals('JBSWY3DPEHPK3PXP'));
+        expect(parsed.groups.first.id, equals('group-id'));
+        expect(parsed.groups.first.name, equals('Work'));
+      });
+
+      test('app data json string should match app data json map', () {
+        final data = AppData(
+          services: const [
+            OtpService(
+              id: 'service-id',
+              name: 'Service Name',
+              secret: 'SECRET123',
+              otp: OtpConfig(
+                account: 'user@example.com',
+                issuer: 'Example Inc',
+              ),
+              order: OrderInfo(position: 1),
+            ),
+          ],
+          groups: const [
+            Group(id: 'group-id', name: 'Example Group'),
+          ],
+        );
+
+        final parsed = AppData.fromJsonString(data.toJsonString());
+
+        expect(parsed.toJson(), equals(data.toJson()));
+      });
+
+      test('should prefer data.bin over data.json when both exist', () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final plaintextData = AppData(
+          services: const [
+            OtpService(
+              id: 'plaintext-service',
+              name: 'Plaintext',
+              secret: 'PLAINTEXTSECRET',
+              otp: OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [
+            Group(id: 'plain-group', name: 'Plain'),
+          ],
+        );
+        final encryptedData = AppData(
+          services: const [
+            OtpService(
+              id: 'vault-service',
+              name: 'Vault',
+              secret: 'VAULTSECRET',
+              otp: OtpConfig(account: 'vault@example.com', issuer: 'Vault'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [
+            Group(id: 'vault-group', name: 'Vault'),
+          ],
+        );
+
+        await repository.writeAppDataJson(plaintextData);
+        final encryptedFile = await repository.getEncryptedLocalFile();
+        final encryptedBytes = await LocalVaultEncryptionService.encrypt(
+          encryptedData.toJsonString(),
+          'vault-password',
+          iterations: 1000,
+        );
+        await encryptedFile.writeAsBytes(encryptedBytes);
+
+        final result =
+            await repository.loadStoredData(password: 'vault-password');
+
+        expect(result.source, equals(StorageDataSource.encryptedVault));
+        expect(result.data.services.single.id, equals('vault-service'));
+        expect(result.data.groups.single.id, equals('vault-group'));
+      });
+
+      test('should require encrypted vault password before reading data.json',
+          () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final plaintextData = AppData(
+          services: const [
+            OtpService(
+              id: 'plaintext-service',
+              name: 'Plaintext',
+              secret: 'PLAINTEXTSECRET',
+              otp: OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [],
+        );
+
+        await repository.writeAppDataJson(plaintextData);
+        final encryptedFile = await repository.getEncryptedLocalFile();
+        final encryptedBytes = await LocalVaultEncryptionService.encrypt(
+          plaintextData.toJsonString(),
+          'vault-password',
+          iterations: 1000,
+        );
+        await encryptedFile.writeAsBytes(encryptedBytes);
+
+        expect(
+          () => repository.loadStoredData(),
+          throwsA(
+            isA<StoragePasswordRequiredException>().having(
+              (error) => error.source,
+              'source',
+              StorageDataSource.encryptedVault,
+            ),
+          ),
+        );
+      });
+
+      test(
+          'should not fall back to data.json after encrypted vault decrypt fails',
+          () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final plaintextData = AppData(
+          services: const [
+            OtpService(
+              id: 'plaintext-service',
+              name: 'Plaintext',
+              secret: 'PLAINTEXTSECRET',
+              otp: OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [
+            Group(id: 'plain-group', name: 'Plain'),
+          ],
+        );
+        final encryptedData = AppData(
+          services: const [
+            OtpService(
+              id: 'vault-service',
+              name: 'Vault',
+              secret: 'VAULTSECRET',
+              otp: OtpConfig(account: 'vault@example.com', issuer: 'Vault'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [
+            Group(id: 'vault-group', name: 'Vault'),
+          ],
+        );
+
+        await repository.writeAppDataJson(plaintextData);
+        final encryptedFile = await repository.getEncryptedLocalFile();
+        final encryptedBytes = await LocalVaultEncryptionService.encrypt(
+          encryptedData.toJsonString(),
+          'vault-password',
+          iterations: 1000,
+        );
+        await encryptedFile.writeAsBytes(encryptedBytes);
+
+        expect(
+          () => repository.loadStoredData(password: 'wrong-password'),
+          throwsA(
+            isA<StorageLoadException>()
+                .having(
+                  (error) => error.source,
+                  'source',
+                  StorageDataSource.encryptedVault,
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('Failed to unlock encrypted vault'),
+                ),
+          ),
+        );
+      });
+
+      test(
+          'should parse decrypted data.bin with the same app-data contract as data.json',
+          () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final data = AppData(
+          services: const [
+            OtpService(
+              id: 'service-id',
+              name: 'GitHub',
+              secret: 'JBSWY3DPEHPK3PXP',
+              otp: OtpConfig(
+                account: 'dev@example.com',
+                issuer: 'GitHub',
+              ),
+              order: OrderInfo(position: 3),
+              groupId: 'group-id',
+            ),
+          ],
+          groups: const [
+            Group(id: 'group-id', name: 'Work'),
+          ],
+        );
+
+        await repository.writeAppDataJson(data);
+        await repository.saveEncryptedData(data, 'vault-password');
+
+        final plaintextJson = await repository.readAppDataJson();
+        final encryptedBytes = await repository.readEncryptedAppData();
+        final decryptedJson = await LocalVaultEncryptionService.decrypt(
+          encryptedBytes,
+          'vault-password',
+        );
+
+        expect(decryptedJson, equals(plaintextJson));
+        expect(
+          repository.parsePlaintextAppData(decryptedJson).toJson(),
+          equals(AppData.fromJsonString(plaintextJson).toJson()),
+        );
+      });
+
+      test('should migrate plaintext data into encrypted vault and delete json',
+          () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final plaintextData = AppData(
+          services: const [
+            OtpService(
+              id: 'plaintext-service',
+              name: 'Plaintext',
+              secret: 'PLAINTEXTSECRET',
+              otp: OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [
+            Group(id: 'plain-group', name: 'Plain'),
+          ],
+        );
+
+        await repository.writeAppDataJson(plaintextData);
+        await repository.migratePlaintextDataToEncryptedVault(
+          plaintextData,
+          'vault-password',
+        );
+
+        final plaintextFile = await repository.getLocalFile();
+        final encryptedFile = await repository.getEncryptedLocalFile();
+        final loaded =
+            await repository.loadStoredData(password: 'vault-password');
+
+        expect(await plaintextFile.exists(), isFalse);
+        expect(await encryptedFile.exists(), isTrue);
+        expect(loaded.source, equals(StorageDataSource.encryptedVault));
+        expect(loaded.data.toJson(), equals(plaintextData.toJson()));
+      });
+
+      test('should save plaintext mode to data.json', () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final data = AppData(
+          services: const [
+            OtpService(
+              id: 'service-id',
+              name: 'Plaintext',
+              secret: 'PLAINTEXTSECRET',
+              otp: OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [],
+        );
+
+        await repository.saveData(data);
+
+        final plaintextFile = await repository.getLocalFile();
+        final encryptedFile = await repository.getEncryptedLocalFile();
+
+        expect(await plaintextFile.exists(), isTrue);
+        expect(await encryptedFile.exists(), isFalse);
+        expect(
+          AppData.fromJsonString(await plaintextFile.readAsString()).toJson(),
+          equals(data.toJson()),
+        );
+      });
+
+      test('should save encrypted mode only to data.bin', () async {
+        final repository = StorageRepository(localPathOverride: tempDir.path);
+        final existingPlaintextData = AppData(
+          services: const [
+            OtpService(
+              id: 'old-service',
+              name: 'Old Plaintext',
+              secret: 'OLDSECRET',
+              otp: OtpConfig(account: 'old@example.com', issuer: 'Old'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [],
+        );
+        final encryptedData = AppData(
+          services: const [
+            OtpService(
+              id: 'vault-service',
+              name: 'Vault',
+              secret: 'VAULTSECRET',
+              otp: OtpConfig(account: 'vault@example.com', issuer: 'Vault'),
+              order: OrderInfo(position: 0),
+            ),
+          ],
+          groups: const [],
+        );
+
+        await repository.writeAppDataJson(existingPlaintextData);
+        await repository.saveData(
+          encryptedData,
+          source: StorageDataSource.encryptedVault,
+          password: 'vault-password',
+        );
+
+        final plaintextFile = await repository.getLocalFile();
+        final encryptedFile = await repository.getEncryptedLocalFile();
+        final loaded =
+            await repository.loadStoredData(password: 'vault-password');
+
+        expect(await plaintextFile.exists(), isFalse);
+        expect(await encryptedFile.exists(), isTrue);
+        expect(loaded.source, equals(StorageDataSource.encryptedVault));
+        expect(loaded.data.toJson(), equals(encryptedData.toJson()));
       });
     });
 

--- a/test/presentation/state/otp_state_test.dart
+++ b/test/presentation/state/otp_state_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,6 +10,7 @@ import 'package:libreotp/domain/services/otp_service.dart';
 import 'package:libreotp/config/display_mode.dart';
 import 'package:libreotp/presentation/state/otp_display_state.dart';
 import 'package:libreotp/presentation/state/otp_state.dart';
+import 'package:libreotp/services/local_vault_encryption_service.dart';
 
 // Mock classes
 class MockStorageRepository extends StorageRepository {
@@ -16,10 +18,14 @@ class MockStorageRepository extends StorageRepository {
   List<OtpService> _services = [];
   bool shouldThrowException = false;
   Object? loadStoredDataException;
+  Object? passwordLoadException;
   LoadedAppData? storedDataResult;
+  LoadedAppData? passwordLoadResult;
   StorageDataSource? savedSource;
   String? encryptedSavePassword;
   AppData? savedData;
+  VaultKdfParameters kdfParameters =
+      VaultKdfParameters(salt: Uint8List(32), iterations: 1000);
   late File _testFile;
 
   MockStorageRepository() {
@@ -27,6 +33,9 @@ class MockStorageRepository extends StorageRepository {
     _testFile = File('${tempDir.path}/test_data.json');
     _testFile.writeAsStringSync('{"groups":[],"services":[]}');
   }
+
+  @override
+  Future<VaultKdfParameters> readVaultKdfParameters() async => kdfParameters;
 
   @override
   Future<AppData> loadData({String? password}) async {
@@ -38,6 +47,14 @@ class MockStorageRepository extends StorageRepository {
 
   @override
   Future<LoadedAppData> loadStoredData({String? password}) async {
+    if (password != null) {
+      if (passwordLoadException != null) {
+        throw passwordLoadException!;
+      }
+      if (passwordLoadResult != null) {
+        return passwordLoadResult!;
+      }
+    }
     if (loadStoredDataException != null) {
       throw loadStoredDataException!;
     }
@@ -53,6 +70,7 @@ class MockStorageRepository extends StorageRepository {
     AppData data, {
     StorageDataSource source = StorageDataSource.plaintextJson,
     String? password,
+    bool verify = false,
   }) async {
     savedData = data;
     savedSource = source;
@@ -301,6 +319,82 @@ void main() {
         await future;
         expect(otpState.isBusy, isFalse);
         expect(otpState.busyMessage, isNull);
+      });
+
+      test(
+          'wrong vault password keeps prompt and sets incorrect password kind',
+          () async {
+        mockRepository.loadStoredDataException =
+            const StoragePasswordRequiredException(
+          StorageDataSource.encryptedVault,
+          'Password required for encrypted vault',
+        );
+        mockRepository.passwordLoadException = const StorageLoadException(
+          StorageDataSource.encryptedVault,
+          'Failed to unlock encrypted vault',
+          kind: VaultLoadErrorKind.incorrectPassword,
+        );
+
+        await otpState.initializeData();
+        expect(otpState.requiresLocalVaultPassword, isTrue);
+
+        await otpState.loadDataWithPassword('wrong-password');
+
+        expect(otpState.requiresPassword, isTrue);
+        expect(otpState.requiresLocalVaultPassword, isTrue);
+        expect(otpState.encryptionErrorKind,
+            equals(VaultLoadErrorKind.incorrectPassword));
+        expect(otpState.usesEncryptedLocalStorage, isFalse);
+        expect(otpState.services, isEmpty);
+      });
+
+      test('successful vault unlock populates services and clears prompt',
+          () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Vault',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'vault@example.com', issuer: 'Vault'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.loadStoredDataException =
+            const StoragePasswordRequiredException(
+          StorageDataSource.encryptedVault,
+          'Password required for encrypted vault',
+        );
+        mockRepository.passwordLoadResult = LoadedAppData(
+          data: AppData(groups: const [], services: [service]),
+          source: StorageDataSource.encryptedVault,
+        );
+
+        await otpState.initializeData();
+        expect(otpState.requiresLocalVaultPassword, isTrue);
+
+        await otpState.loadDataWithPassword('correct-password');
+
+        expect(otpState.usesEncryptedLocalStorage, isTrue);
+        expect(otpState.requiresPassword, isFalse);
+        expect(otpState.encryptionErrorKind, isNull);
+        expect(otpState.services.length, equals(1));
+      });
+
+      test('changeLocalVaultPassword throws when vault is not active',
+          () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Plaintext',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.setTestData(const [], [service]);
+        await otpState.initializeData();
+
+        expect(otpState.usesEncryptedLocalStorage, isFalse);
+        expect(
+          () => otpState.changeLocalVaultPassword('new-password'),
+          throwsA(isA<StateError>()),
+        );
       });
     });
 

--- a/test/presentation/state/otp_state_test.dart
+++ b/test/presentation/state/otp_state_test.dart
@@ -7,6 +7,7 @@ import 'package:libreotp/data/models/group.dart';
 import 'package:libreotp/data/models/otp_service.dart';
 import 'package:libreotp/data/repositories/storage_repository.dart';
 import 'package:libreotp/domain/services/otp_service.dart';
+import 'package:libreotp/config/app_config.dart';
 import 'package:libreotp/config/display_mode.dart';
 import 'package:libreotp/presentation/state/otp_display_state.dart';
 import 'package:libreotp/presentation/state/otp_state.dart';
@@ -253,6 +254,55 @@ void main() {
 
         expect(otpState.shouldPromptForEncryptionMigration, isTrue);
         expect(otpState.canEncryptLocalData, isTrue);
+      });
+
+      test('should not offer encryption migration once it has been dismissed',
+          () async {
+        SharedPreferences.setMockInitialValues(
+            {'encryption_migration_dismissed': true});
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Plaintext',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.storedDataResult = LoadedAppData(
+          data: AppData(groups: const [], services: [service]),
+          source: StorageDataSource.plaintextJson,
+        );
+
+        await otpState.initializeData();
+
+        expect(otpState.shouldPromptForEncryptionMigration, isFalse);
+        expect(otpState.canEncryptLocalData, isTrue);
+      });
+
+      test(
+          'should not re-offer encryption migration after dismissal on relaunch',
+          () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Plaintext',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.storedDataResult = LoadedAppData(
+          data: AppData(groups: const [], services: [service]),
+          source: StorageDataSource.plaintextJson,
+        );
+        await otpState.initializeData();
+        expect(otpState.shouldPromptForEncryptionMigration, isTrue);
+
+        otpState.dismissEncryptionMigrationPrompt();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(await AppConfig.getEncryptionMigrationDismissed(), isTrue);
+
+        final relaunched = OtpState(mockRepository, mockGenerator);
+        await relaunched.initializeData();
+        expect(relaunched.shouldPromptForEncryptionMigration, isFalse);
+        relaunched.dispose();
       });
 
       test('should migrate plaintext data to encrypted vault', () async {

--- a/test/presentation/state/otp_state_test.dart
+++ b/test/presentation/state/otp_state_test.dart
@@ -15,6 +15,11 @@ class MockStorageRepository extends StorageRepository {
   List<Group> _groups = [];
   List<OtpService> _services = [];
   bool shouldThrowException = false;
+  Object? loadStoredDataException;
+  LoadedAppData? storedDataResult;
+  StorageDataSource? savedSource;
+  String? encryptedSavePassword;
+  AppData? savedData;
   late File _testFile;
 
   MockStorageRepository() {
@@ -32,7 +37,39 @@ class MockStorageRepository extends StorageRepository {
   }
 
   @override
-  Future<void> saveData(AppData data) async {}
+  Future<LoadedAppData> loadStoredData({String? password}) async {
+    if (loadStoredDataException != null) {
+      throw loadStoredDataException!;
+    }
+    return storedDataResult ??
+        LoadedAppData(
+          data: AppData(groups: _groups, services: _services),
+          source: StorageDataSource.plaintextJson,
+        );
+  }
+
+  @override
+  Future<void> saveData(
+    AppData data, {
+    StorageDataSource source = StorageDataSource.plaintextJson,
+    String? password,
+  }) async {
+    savedData = data;
+    savedSource = source;
+    encryptedSavePassword = password;
+  }
+
+  @override
+  Future<void> migratePlaintextDataToEncryptedVault(
+    AppData data,
+    String password,
+  ) async {
+    await saveData(
+      data,
+      source: StorageDataSource.encryptedVault,
+      password: password,
+    );
+  }
 
   @override
   Future<File> getLocalFile() async => _testFile;
@@ -43,6 +80,10 @@ class MockStorageRepository extends StorageRepository {
   void setTestData(List<Group> groups, List<OtpService> services) {
     _groups = groups;
     _services = services;
+    storedDataResult = LoadedAppData(
+      data: AppData(groups: groups, services: services),
+      source: StorageDataSource.plaintextJson,
+    );
   }
 }
 
@@ -142,6 +183,124 @@ void main() {
         expect(otpState, isA<ChangeNotifier>());
         expect(() => otpState.addListener(() {}), returnsNormally);
         expect(() => otpState.removeListener(() {}), returnsNormally);
+      });
+    });
+
+    group('Local vault encryption', () {
+      test('should require local vault password when encrypted vault exists',
+          () async {
+        mockRepository.loadStoredDataException =
+            const StoragePasswordRequiredException(
+          StorageDataSource.encryptedVault,
+          'Password required for encrypted vault',
+        );
+
+        await otpState.initializeData();
+
+        expect(otpState.requiresPassword, isTrue);
+        expect(otpState.requiresLocalVaultPassword, isTrue);
+        expect(otpState.requiresBackupPassword, isFalse);
+      });
+
+      test('should require backup password for encrypted backup json',
+          () async {
+        mockRepository.loadStoredDataException =
+            const StoragePasswordRequiredException(
+          StorageDataSource.encryptedBackupJson,
+          'Password required for encrypted backup',
+        );
+
+        await otpState.initializeData();
+
+        expect(otpState.requiresPassword, isTrue);
+        expect(otpState.requiresBackupPassword, isTrue);
+        expect(otpState.requiresLocalVaultPassword, isFalse);
+      });
+
+      test('should offer encryption migration after plaintext startup',
+          () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Plaintext',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.storedDataResult = LoadedAppData(
+          data: AppData(groups: const [], services: [service]),
+          source: StorageDataSource.plaintextJson,
+        );
+
+        await otpState.initializeData();
+
+        expect(otpState.shouldPromptForEncryptionMigration, isTrue);
+        expect(otpState.canEncryptLocalData, isTrue);
+      });
+
+      test('should migrate plaintext data to encrypted vault', () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Plaintext',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.setTestData(const [], [service]);
+        await otpState.initializeData();
+
+        await otpState.migratePlaintextDataToEncryptedVault('vault-password');
+
+        expect(otpState.usesEncryptedLocalStorage, isTrue);
+        expect(otpState.shouldPromptForEncryptionMigration, isFalse);
+        expect(mockRepository.savedSource,
+            equals(StorageDataSource.encryptedVault));
+        expect(mockRepository.encryptedSavePassword, equals('vault-password'));
+      });
+
+      test(
+          'should change local vault password when encrypted storage is active',
+          () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Vault',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'vault@example.com', issuer: 'Vault'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.storedDataResult = LoadedAppData(
+          data: AppData(groups: const [], services: [service]),
+          source: StorageDataSource.encryptedVault,
+        );
+        await otpState.loadDataWithPassword('old-password');
+
+        await otpState.changeLocalVaultPassword('new-password');
+
+        expect(mockRepository.savedSource,
+            equals(StorageDataSource.encryptedVault));
+        expect(mockRepository.encryptedSavePassword, equals('new-password'));
+      });
+
+      test('should expose busy state while migrating plaintext data', () async {
+        final service = OtpService(
+          id: 'service-1',
+          name: 'Plaintext',
+          secret: 'SECRET',
+          otp: const OtpConfig(account: 'plain@example.com', issuer: 'Plain'),
+          order: const OrderInfo(position: 0),
+        );
+        mockRepository.setTestData(const [], [service]);
+        await otpState.initializeData();
+
+        final future =
+            otpState.migratePlaintextDataToEncryptedVault('vault-password');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(otpState.isBusy, isTrue);
+        expect(otpState.busyMessage, equals('Encrypting local data...'));
+
+        await future;
+        expect(otpState.isBusy, isFalse);
+        expect(otpState.busyMessage, isNull);
       });
     });
 

--- a/test/presentation/widgets/password_dialog_test.dart
+++ b/test/presentation/widgets/password_dialog_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:libreotp/data/repositories/storage_repository.dart';
 import 'package:libreotp/presentation/widgets/password_dialog.dart';
 
 void main() {
@@ -140,6 +141,57 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(result, equals('matching-password'));
+    });
+
+    testWidgets('shows change vault password copy and confirm field',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(mode: PasswordDialogMode.changeVaultPassword),
+      );
+
+      expect(find.text('Change Vault Password'), findsOneWidget);
+      expect(find.text('Change Password'), findsOneWidget);
+      expect(find.byType(TextField), findsNWidgets(2));
+      expect(find.widgetWithText(TextField, 'New Password'), findsOneWidget);
+      expect(
+        find.widgetWithText(TextField, 'Confirm Password'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders corrupted vault error copy',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(
+          mode: PasswordDialogMode.unlockVault,
+          errorKind: VaultLoadErrorKind.corruptedVault,
+        ),
+      );
+
+      expect(
+        find.text(
+          'This vault file appears to be corrupted or was created by a newer version.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders incorrect password error copy',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(
+          mode: PasswordDialogMode.unlockVault,
+          errorKind: VaultLoadErrorKind.incorrectPassword,
+        ),
+      );
+
+      expect(
+        find.text('Incorrect password. Please try again.'),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/presentation/widgets/password_dialog_test.dart
+++ b/test/presentation/widgets/password_dialog_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libreotp/presentation/widgets/password_dialog.dart';
+
+void main() {
+  Widget buildDialog(PasswordDialog dialog) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              showDialog<String>(
+                context: context,
+                builder: (_) => dialog,
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openDialog(
+    WidgetTester tester,
+    PasswordDialog dialog,
+  ) async {
+    await tester.pumpWidget(buildDialog(dialog));
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('PasswordDialog', () {
+    testWidgets('shows vault unlock copy and action label',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(mode: PasswordDialogMode.unlockVault),
+      );
+
+      expect(find.text('Encrypted Vault Detected'), findsOneWidget);
+      expect(
+        find.text(
+          'This local vault is encrypted. Enter the password to unlock your stored services.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Unlock'), findsOneWidget);
+    });
+
+    testWidgets('shows backup decrypt copy and action label',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(mode: PasswordDialogMode.decryptBackup),
+      );
+
+      expect(find.text('Encrypted Backup Detected'), findsOneWidget);
+      expect(
+        find.text(
+          'This backup file is encrypted. Enter the password to decrypt it.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Decrypt'), findsOneWidget);
+    });
+
+    testWidgets('shows confirmation field in create vault mode',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(mode: PasswordDialogMode.createVaultPassword),
+      );
+
+      expect(find.text('Create Vault Password'), findsOneWidget);
+      expect(find.text('New Password'), findsOneWidget);
+      expect(find.text('Confirm Password'), findsOneWidget);
+      expect(find.text('Create Vault'), findsOneWidget);
+    });
+
+    testWidgets('shows mismatch error in create vault mode',
+        (WidgetTester tester) async {
+      await openDialog(
+        tester,
+        const PasswordDialog(mode: PasswordDialogMode.createVaultPassword),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'New Password'),
+        'password-one',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Confirm Password'),
+        'password-two',
+      );
+      await tester.tap(find.text('Create Vault'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Passwords do not match. Please try again.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('returns password when vault creation confirmation matches',
+        (WidgetTester tester) async {
+      String? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () async {
+                  result = await showDialog<String>(
+                    context: context,
+                    builder: (_) => const PasswordDialog(
+                      mode: PasswordDialogMode.createVaultPassword,
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'New Password'),
+        'matching-password',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Confirm Password'),
+        'matching-password',
+      );
+      await tester.tap(find.text('Create Vault'));
+      await tester.pumpAndSettle();
+
+      expect(result, equals('matching-password'));
+    });
+  });
+}

--- a/test/services/crypto_primitives_test.dart
+++ b/test/services/crypto_primitives_test.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libreotp/services/crypto_primitives.dart';
+
+void main() {
+  group('crypto primitives', () {
+    test('derive key, encrypt and decrypt round trip', () {
+      final salt = Uint8List.fromList(List.generate(16, (i) => i));
+      final nonce = Uint8List.fromList(List.generate(12, (i) => i + 1));
+      final aad = Uint8List.fromList(utf8.encode('metadata'));
+      final plaintext = Uint8List.fromList(utf8.encode('hello primitives'));
+
+      final key = derivePbkdf2HmacSha256Key('password', salt, 1000, 32);
+      expect(key.length, 32);
+
+      final ciphertextWithTag = aesGcmEncrypt(key, nonce, plaintext, aad, 16);
+      final decrypted = aesGcmDecrypt(key, nonce, ciphertextWithTag, aad, 16);
+
+      expect(decrypted, plaintext);
+    });
+
+    test('encrypt and decrypt round trip empty plaintext', () {
+      final salt = Uint8List.fromList(List.generate(16, (i) => i));
+      final nonce = Uint8List.fromList(List.generate(12, (i) => i + 1));
+      final aad = Uint8List.fromList(utf8.encode('metadata'));
+      final plaintext = Uint8List(0);
+
+      final key = derivePbkdf2HmacSha256Key('password', salt, 1000, 32);
+      final ciphertextWithTag = aesGcmEncrypt(key, nonce, plaintext, aad, 16);
+      expect(ciphertextWithTag.length, 16);
+      final decrypted = aesGcmDecrypt(key, nonce, ciphertextWithTag, aad, 16);
+
+      expect(decrypted, plaintext);
+    });
+
+    test('decrypt throws on wrong key', () {
+      final salt = Uint8List.fromList(List.generate(16, (i) => i));
+      final nonce = Uint8List.fromList(List.generate(12, (i) => i + 1));
+      final aad = Uint8List(0);
+      final plaintext = Uint8List.fromList(utf8.encode('secret'));
+
+      final key = derivePbkdf2HmacSha256Key('password', salt, 1000, 32);
+      final wrongKey = derivePbkdf2HmacSha256Key('other', salt, 1000, 32);
+      final ciphertextWithTag = aesGcmEncrypt(key, nonce, plaintext, aad, 16);
+
+      expect(
+        () => aesGcmDecrypt(wrongKey, nonce, ciphertextWithTag, aad, 16),
+        throwsA(anything),
+      );
+    });
+  });
+}

--- a/test/services/local_vault_encryption_service_test.dart
+++ b/test/services/local_vault_encryption_service_test.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libreotp/services/local_vault_encryption_service.dart';
+
+void main() {
+  group('LocalVaultEncryptionService', () {
+    const password = 'correct horse battery staple';
+    const plaintextJson =
+        '{"services":[{"name":"GitHub","secret":"JBSWY3DPEHPK3PXP"}],"groups":[]}';
+
+    test('should encrypt and decrypt the exact app data JSON payload',
+        () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+
+      final decrypted = await LocalVaultEncryptionService.decrypt(
+        vaultBytes,
+        password,
+      );
+
+      expect(decrypted, equals(plaintextJson));
+    });
+
+    test('should write a versioned encrypted vault envelope', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+      final envelope =
+          jsonDecode(utf8.decode(vaultBytes)) as Map<String, dynamic>;
+
+      expect(envelope['magic'], equals(LocalVaultEncryptionService.magic));
+      expect(envelope['version'], equals(LocalVaultEncryptionService.version));
+      expect(
+          envelope['kdf']['name'], equals(LocalVaultEncryptionService.kdfName));
+      expect(envelope['kdf']['iterations'], equals(1000));
+      expect(envelope['cipher']['name'],
+          equals(LocalVaultEncryptionService.cipherName));
+      expect(envelope['ciphertext'], isA<String>());
+      expect(envelope.containsKey('services'), isFalse);
+      expect(envelope.containsKey('groups'), isFalse);
+    });
+
+    test('should reject an incorrect password', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(vaultBytes, 'wrong password'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should reject corrupted ciphertext', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+      final envelope =
+          jsonDecode(utf8.decode(vaultBytes)) as Map<String, dynamic>;
+      final ciphertext = base64.decode(envelope['ciphertext'] as String);
+      ciphertext[0] = ciphertext[0] ^ 0x01;
+      envelope['ciphertext'] = base64.encode(ciphertext);
+      final corruptedBytes =
+          Uint8List.fromList(utf8.encode(jsonEncode(envelope)));
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(corruptedBytes, password),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should reject unsupported vault versions', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+      final envelope =
+          jsonDecode(utf8.decode(vaultBytes)) as Map<String, dynamic>;
+      envelope['version'] = LocalVaultEncryptionService.version + 1;
+      final unsupportedBytes =
+          Uint8List.fromList(utf8.encode(jsonEncode(envelope)));
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(unsupportedBytes, password),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('should reject malformed vault data', () async {
+      final malformedBytes = Uint8List.fromList(utf8.encode('not json'));
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(malformedBytes, password),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}

--- a/test/services/local_vault_encryption_service_test.dart
+++ b/test/services/local_vault_encryption_service_test.dart
@@ -106,5 +106,91 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('should reject iterations above the maximum bound', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+      final envelope =
+          jsonDecode(utf8.decode(vaultBytes)) as Map<String, dynamic>;
+      envelope['kdf']['iterations'] =
+          LocalVaultEncryptionService.maxIterations + 1;
+      final tamperedBytes =
+          Uint8List.fromList(utf8.encode(jsonEncode(envelope)));
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(tamperedBytes, password),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('should round trip unicode password and emoji plaintext', () async {
+      const unicodePassword = 'pâsswörd-ǔnicode-🔐';
+      const unicodePlaintext = '{"note":"héllo wörld 🚀🔑 日本語"}';
+
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        unicodePlaintext,
+        unicodePassword,
+        iterations: 1000,
+      );
+
+      final decrypted = await LocalVaultEncryptionService.decrypt(
+        vaultBytes,
+        unicodePassword,
+      );
+
+      expect(decrypted, equals(unicodePlaintext));
+    });
+
+    test('should throw when encrypting with an empty password', () async {
+      expect(
+        () => LocalVaultEncryptionService.encrypt('', '', iterations: 1000),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when decrypting with an empty password', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 1000,
+      );
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(vaultBytes, ''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should round-trip empty plaintext', () async {
+      final vault = await LocalVaultEncryptionService.encrypt(
+        '',
+        'pw',
+        iterations: 1000,
+      );
+      expect(await LocalVaultEncryptionService.decrypt(vault, 'pw'), equals(''));
+    });
+
+    test('should reject tampered KDF iterations bound by AAD', () async {
+      final vaultBytes = await LocalVaultEncryptionService.encrypt(
+        plaintextJson,
+        password,
+        iterations: 5000,
+      );
+      final envelope =
+          jsonDecode(utf8.decode(vaultBytes)) as Map<String, dynamic>;
+      final kdf = envelope['kdf'] as Map<String, dynamic>;
+      expect(kdf['iterations'], equals(5000));
+      kdf['iterations'] = 6000;
+      final tamperedBytes =
+          Uint8List.fromList(utf8.encode(jsonEncode(envelope)));
+
+      expect(
+        () => LocalVaultEncryptionService.decrypt(tamperedBytes, password),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
  Adds optional encryption for local LibreOTP data by migrating plaintext `data.json` storage into an encrypted `data.bin` vault.

  This includes:
  - AES-GCM encrypted local vault support using PBKDF2-HMAC-SHA256 key derivation
  - Prefer `data.bin` over `data.json` when both exist
  - Prompt to migrate existing plaintext local data into the encrypted vault
  - Password dialogs for creating, unlocking, and changing the vault password
  - Loading overlays while encrypted data is being unlocked, encrypted, or re-saved
  - Tests for vault encryption, storage behavior, password dialogs, and state transitions